### PR TITLE
feat: MCP管理CLIと連携機能を実装

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,7 +4,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2022,
     sourceType: 'module',
-    project: './tsconfig.json'
+    project: './tsconfig.eslint.json'
   },
   plugins: ['@typescript-eslint'],
   extends: [
@@ -19,7 +19,7 @@ module.exports = {
   },
   rules: {
     // TypeScript rules
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     'no-unused-vars': 'off',
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/explicit-function-return-type': 'error',
@@ -31,13 +31,24 @@ module.exports = {
     'no-console': 'off',
     'eqeqeq': 'error',
     'no-eval': 'error',
-    'no-implied-eval': 'error'
+    'no-implied-eval': 'error',
+
+    // Additional TypeScript specific rules for consistent coding style
+    '@typescript-eslint/no-unsafe-assignment': 'error',
+    '@typescript-eslint/no-unsafe-return': 'error',
+    '@typescript-eslint/no-unsafe-member-access': 'error',
+    '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/prefer-readonly': 'error'
   },
   overrides: [
     {
-      files: ['**/*.test.ts', '**/*.spec.ts'],
+      files: ['**/*.test.ts'],
       rules: {
-        'no-console': 'off'
+        'no-console': 'off',
+        '@typescript-eslint/no-unsafe-assignment': 'off',
+        '@typescript-eslint/no-unsafe-member-access': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-unsafe-call': 'off'
       }
     }
   ]

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,44 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    project: './tsconfig.json'
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended'
+  ],
+  env: {
+    node: true,
+    es6: true
+  },
+  globals: {
+    NodeJS: 'readonly'
+  },
+  rules: {
+    // TypeScript rules
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/explicit-function-return-type': 'error',
+    '@typescript-eslint/no-non-null-assertion': 'error',
+
+    // General rules
+    'no-var': 'error',
+    'prefer-const': 'error',
+    'no-console': 'off',
+    'eqeqeq': 'error',
+    'no-eval': 'error',
+    'no-implied-eval': 'error'
+  },
+  overrides: [
+    {
+      files: ['**/*.test.ts', '**/*.spec.ts'],
+      rules: {
+        'no-console': 'off'
+      }
+    }
+  ]
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build output
+dist/
+build/
+*.tsbuildinfo
+
+# Coverage reports
+coverage/
+*.lcov
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Logs
+logs/
+*.log
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Test files created during development
+test-config.json
+invalid-config.json
+single-entry.json
+
+# Temporary files
+*.tmp
+*.temp

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 manage_mcp contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
 # manage_mcp
+
+CLI ツール manage_mcp は Model Context Protocol (MCP) のレジストリエントリを作成・更新・移行するためのコマンドセットを提供します。バックアップ生成や外部ツールとのインポート／エクスポートを自動化し、ローカル設定の一貫性を保ちます。
+
+## 特徴
+- 既存の MCP レジストリ (`mcp.json`) を読み書きし、存在しない場合は自動初期化
+- 追加・削除コマンドでの検証、バックアップ作成、ソート済み出力
+- Claude Code / Claude Desktop / Cursor / Codex との設定インポート・エクスポート
+- `--verbose` フラグによる詳細ログ出力
+
+## 必要条件
+- Node.js 20 以上
+- npm もしくは互換パッケージマネージャー
+
+## セットアップ
+```bash
+npm install
+npm run build
+```
+ビルド後は `npx manage-mcp --help` で利用可能なコマンドを確認できます。開発中に継続的にコンパイルする場合は `npm run dev` を使用してください。
+
+## 基本的な使い方
+### エントリ一覧
+```bash
+npx manage-mcp list
+```
+既存エントリを名前順に表示します。レジストリが存在しない場合は `~/.manage_mcp/mcp.json` を初期化します。
+
+### エントリ追加
+```bash
+npx manage-mcp add sample --config ./configs/sample.json
+```
+- `--config` は MCP エントリを含む JSON ファイルを指します。
+- 追加前にスキーマバリデーションとバックアップ作成を行います。
+
+### エントリ削除
+```bash
+npx manage-mcp remove sample
+```
+指定エントリを削除し、変更前にバックアップ (`mcp.json.bak`) を作成します。
+
+### 外部ツールからのインポート
+```bash
+npx manage-mcp import ClaudeCode --force
+```
+- 指定ツール (ClaudeCode / ClaudeDesktop / Cursor / Codex) からエントリを取り込みます。
+- `--force` を付けると既存エントリを上書きします。
+
+### 外部ツールへのエクスポート
+```bash
+npx manage-mcp export ClaudeCode Cursor
+```
+複数ツールを同時に指定できます。
+
+## 設定ファイル
+- 既定パスは `~/.manage_mcp/mcp.json`
+- バックアップは同ディレクトリの `mcp.json.bak`
+- `MCP_CONFIG_DIR` 環境変数で保存先ディレクトリを変更できます
+
+## プロジェクト構成
+- `src/cli.ts`: Commander ベースの CLI エントリポイント
+- `src/services/`: 設定入出力、検証、インポート／エクスポートのビジネスロジック
+- `src/source-readers/`, `src/target-writers/`: 各ツール向けアダプタ
+- `src/types/`: 共有型定義
+- `src/infra/logger.ts`: ログユーティリティ
+- `tests/`: Vitest によるサービス／アダプタ単位の統合テスト
+
+## 開発用スクリプト
+- `npm run lint`: ESLint による静的解析
+- `npm run lint:fix`: 自動修正付き ESLint
+- `npm run typecheck`: TypeScript 型チェック
+- `npm test`: Vitest 実行
+- `npm run test:coverage`: カバレッジ計測付きテスト
+
+## ライセンス
+本リポジトリは [MIT License](./LICENSE) の下で提供されています。

--- a/README.md
+++ b/README.md
@@ -27,11 +27,23 @@ npx manage-mcp list
 既存エントリを名前順に表示します。レジストリが存在しない場合は `~/.manage_mcp/mcp.json` を初期化します。
 
 ### エントリ追加
+ローカル実行型 (stdio) の MCP サーバーを登録する例:
 ```bash
-npx manage-mcp add sample --config ./configs/sample.json
+npx manage-mcp add local-runner node ./scripts/server.js -- --watch
 ```
-- `--config` は MCP エントリを含む JSON ファイルを指します。
-- 追加前にスキーマバリデーションとバックアップ作成を行います。
+- 第2引数にコマンド本体 (`node` など)、第3引数以降に引数を渡します。`--` 以降は CLI のオプション解析を終了してコマンド引数として扱います。
+- `--env KEY=VALUE` で環境変数を複数指定できます。
+- `--project-path <path>` を付けると `project_path` フィールドを設定できます。
+
+リモート (SSE) エンドポイントを登録する例:
+```bash
+npx manage-mcp add claude-remote https://example.com/mcp --transport sse \
+  -H "Authorization: Bearer <TOKEN>" \
+  -e "ORG_ID=12345"
+```
+- `--transport` に `sse` または `http` を指定すると URL ベースの登録になり、`target` 引数もしくは `--url` オプションで接続先を渡します。
+- `-H/--header KEY: VALUE` でヘッダーを、`-e/--env` で環境変数を設定できます。
+- scope は現状 `user` 固定です。
 
 ### エントリ削除
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3801 @@
+{
+  "name": "manage-mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "manage-mcp",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.0.0"
+      },
+      "bin": {
+        "manage-mcp": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@typescript-eslint/eslint-plugin": "^7.0.0",
+        "@typescript-eslint/parser": "^7.0.0",
+        "@vitest/coverage-v8": "^1.0.0",
+        "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.0.0",
+        "eslint-plugin-functional": "^6.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.2.tgz",
+      "integrity": "sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.2.tgz",
+      "integrity": "sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.2.tgz",
+      "integrity": "sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.2.tgz",
+      "integrity": "sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.2.tgz",
+      "integrity": "sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.2.tgz",
+      "integrity": "sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.2.tgz",
+      "integrity": "sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.2.tgz",
+      "integrity": "sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.2.tgz",
+      "integrity": "sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.2.tgz",
+      "integrity": "sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.50.2.tgz",
+      "integrity": "sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.2.tgz",
+      "integrity": "sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.2.tgz",
+      "integrity": "sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.2.tgz",
+      "integrity": "sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.2.tgz",
+      "integrity": "sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.2.tgz",
+      "integrity": "sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.2.tgz",
+      "integrity": "sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.2.tgz",
+      "integrity": "sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.2.tgz",
+      "integrity": "sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.2.tgz",
+      "integrity": "sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.2.tgz",
+      "integrity": "sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.15.tgz",
+      "integrity": "sha512-W3bqcbLsRdFDVcmAM5l6oLlcl67vjevn8j1FPZ4nx+K5jNoWCh+FC/btxFoBPnvQlrHHDwfjp1kjIEDfwJ0Mog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
+      "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.4",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.4",
+        "istanbul-reports": "^3.1.6",
+        "magic-string": "^0.30.5",
+        "magicast": "^0.3.3",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "test-exclude": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "1.6.1"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge-ts": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz",
+      "integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-functional": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-functional/-/eslint-plugin-functional-6.6.3.tgz",
+      "integrity": "sha512-sVbbvNvwX3HVkXAykKyoNLv57r4DPF7f1sy+/8j4YtzLYVQPGljMUWv3T6Kd4lwnnjmcKuj0EkIbS+knL6P5jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^7.3.1",
+        "deepmerge-ts": "^5.1.0",
+        "escape-string-regexp": "^4.0.0",
+        "is-immutable-type": "^4.0.0",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=16.10.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0",
+        "typescript": ">=4.3.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-immutable-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-immutable-type/-/is-immutable-type-4.0.0.tgz",
+      "integrity": "sha512-gyFBCXv+NikTs8/PGZhgjbMmFZQ5jvHGZIsVu6+/9Bk4K7imlWBIDN7hTr9fNioGzFg71I4YM3z8f0aKXarTAw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@typescript-eslint/type-utils": "^7.2.0",
+        "ts-api-utils": "^1.3.0",
+        "ts-declaration-location": "^1.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": ">=4.7.4"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
+      "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.50.2",
+        "@rollup/rollup-android-arm64": "4.50.2",
+        "@rollup/rollup-darwin-arm64": "4.50.2",
+        "@rollup/rollup-darwin-x64": "4.50.2",
+        "@rollup/rollup-freebsd-arm64": "4.50.2",
+        "@rollup/rollup-freebsd-x64": "4.50.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.50.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.50.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.50.2",
+        "@rollup/rollup-linux-arm64-musl": "4.50.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.50.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.50.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.50.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.50.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.50.2",
+        "@rollup/rollup-linux-x64-gnu": "4.50.2",
+        "@rollup/rollup-linux-x64-musl": "4.50.2",
+        "@rollup/rollup-openharmony-arm64": "4.50.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.50.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.50.2",
+        "@rollup/rollup-win32-x64-msvc": "4.50.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-declaration-location": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
+      "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "picomatch": "^4.0.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.0.0"
+      }
+    },
+    "node_modules/ts-declaration-location/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "commander": "^12.0.0"
       },
       "bin": {
         "manage-mcp": "dist/cli.js"
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^20.19.15",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "@vitest/coverage-v8": "^1.0.0",
@@ -639,6 +640,12 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "dev": "tsc --watch",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix",
+    "lint": "eslint --ext .ts src tests",
+    "lint:fix": "eslint --ext .ts src tests --fix",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "manage-mcp",
+  "version": "1.0.0",
+  "description": "CLI tool for managing MCP (Model Context Protocol) configurations",
+  "type": "module",
+  "main": "dist/cli.js",
+  "bin": {
+    "manage-mcp": "./dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "test:coverage": "vitest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "lint:fix": "eslint src/**/*.ts --fix",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "cli",
+    "configuration",
+    "typescript"
+  ],
+  "author": "",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-functional": "^6.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  },
+  "dependencies": {
+    "commander": "^12.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^20.19.15",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "@vitest/coverage-v8": "^1.0.0",
@@ -40,6 +40,7 @@
     "vitest": "^1.0.0"
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "commander": "^12.0.0"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+import { promises as fs } from 'fs';
+import { resolveConfigPaths, readRegistry, writeRegistry, ensureBackup } from './services/config-service.js';
+import { sortEntries, addEntry, removeEntry } from './services/mcp-service.js';
+import { validateEntry } from './services/validation.js';
+import { createLogger } from './infra/logger.js';
+import type { McpEntry } from './types/index.js';
+
+const program = new Command();
+
+program
+  .name('manage-mcp')
+  .description('CLI tool for managing MCP (Model Context Protocol) configurations')
+  .version('1.0.0');
+
+program
+  .option('--verbose', 'Enable verbose logging', false);
+
+const getLogger = (): ReturnType<typeof createLogger> => {
+  const options = program.opts();
+  return createLogger(options.verbose);
+};
+
+const formatEntryDisplay = (name: string, entry: McpEntry): string => {
+  const parts = [`${name}:`];
+  parts.push(`  command: ${entry.command}`);
+
+  if (entry.args && entry.args.length > 0) {
+    parts.push(`  args: [${entry.args.map(arg => `"${arg}"`).join(', ')}]`);
+  }
+
+  if (entry.type) {
+    parts.push(`  type: ${entry.type}`);
+  }
+
+  if (entry.env && Object.keys(entry.env).length > 0) {
+    parts.push('  env:');
+    Object.entries(entry.env).forEach(([key, value]) => {
+      parts.push(`    ${key}: ${value}`);
+    });
+  }
+
+  return parts.join('\n');
+};
+
+const formatValidationErrors = (errors: readonly { path: string; reason: string }[]): string => {
+  const summary = `Validation failed with ${errors.length} error(s):`;
+  const details = errors.map(error => `  ${error.path}: ${error.reason}`).join('\n');
+  return `${summary}\n${details}`;
+};
+
+program
+  .command('list')
+  .description('List all MCP entries')
+  .action(async () => {
+    const logger = getLogger();
+    logger.info('Listing MCP entries');
+
+    try {
+      const paths = resolveConfigPaths(process.env);
+      const registryResult = await readRegistry(paths);
+
+      if (!registryResult.success) {
+        logger.error(`Failed to read registry: ${registryResult.error.message}`);
+        process.exit(1);
+      }
+
+      const entries = sortEntries(registryResult.data);
+
+      if (entries.length === 0) {
+        logger.info('No MCP entries found');
+        return;
+      }
+
+      entries.forEach(({ name, entry }) => {
+        console.log(formatEntryDisplay(name, entry));
+        console.log('');
+      });
+
+      logger.info(`Total entries: ${entries.length}`);
+    } catch (error) {
+      logger.error(`Unexpected error: ${error}`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('add')
+  .description('Add a new MCP entry')
+  .argument('<name>', 'Name of the MCP entry')
+  .requiredOption('--config <path>', 'Path to the MCP configuration file')
+  .action(async (name: string, options: { config: string }) => {
+    const logger = getLogger();
+    logger.info(`Adding MCP entry: ${name}`);
+
+    try {
+      const paths = resolveConfigPaths(process.env);
+
+      // Read external config
+      const configContent = await fs.readFile(options.config, 'utf8');
+      const externalEntry = JSON.parse(configContent) as McpEntry;
+
+      // Validate the entry
+      const validationErrors = validateEntry(name, externalEntry);
+      if (validationErrors.length > 0) {
+        logger.error(formatValidationErrors(validationErrors));
+        process.exit(1);
+      }
+
+      // Read existing registry
+      const registryResult = await readRegistry(paths);
+      if (!registryResult.success) {
+        logger.error(`Failed to read registry: ${registryResult.error.message}`);
+        process.exit(1);
+      }
+
+      // Create backup
+      const backupResult = await ensureBackup(paths);
+      if (!backupResult.success) {
+        logger.error(`Failed to create backup: ${backupResult.error.message}`);
+        process.exit(1);
+      }
+
+      // Add entry and write
+      const newRegistry = addEntry(registryResult.data, name, externalEntry);
+      const writeResult = await writeRegistry(paths, newRegistry);
+
+      if (!writeResult.success) {
+        logger.error(`Failed to write registry: ${writeResult.error.message}`);
+        process.exit(1);
+      }
+
+      logger.info(`Successfully added MCP entry: ${name}`);
+      console.log(formatEntryDisplay(name, externalEntry));
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        logger.error(`Invalid JSON in config file: ${error.message}`);
+      } else if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        logger.error(`Config file not found: ${options.config}`);
+      } else {
+        logger.error(`Unexpected error: ${error}`);
+      }
+      process.exit(1);
+    }
+  });
+
+program
+  .command('remove')
+  .description('Remove an MCP entry')
+  .argument('<name>', 'Name of the MCP entry to remove')
+  .action(async (name: string) => {
+    const logger = getLogger();
+    logger.info(`Removing MCP entry: ${name}`);
+
+    try {
+      const paths = resolveConfigPaths(process.env);
+
+      // Read existing registry
+      const registryResult = await readRegistry(paths);
+      if (!registryResult.success) {
+        logger.error(`Failed to read registry: ${registryResult.error.message}`);
+        process.exit(1);
+      }
+
+      // Check if entry exists
+      if (!(name in registryResult.data)) {
+        logger.warn(`MCP entry '${name}' not found`);
+        return;
+      }
+
+      // Create backup
+      const backupResult = await ensureBackup(paths);
+      if (!backupResult.success) {
+        logger.error(`Failed to create backup: ${backupResult.error.message}`);
+        process.exit(1);
+      }
+
+      // Remove entry and write
+      const newRegistry = removeEntry(registryResult.data, name);
+      const writeResult = await writeRegistry(paths, newRegistry);
+
+      if (!writeResult.success) {
+        logger.error(`Failed to write registry: ${writeResult.error.message}`);
+        process.exit(1);
+      }
+
+      logger.info(`Successfully removed MCP entry: ${name}`);
+    } catch (error) {
+      logger.error(`Unexpected error: ${error}`);
+      process.exit(1);
+    }
+  });
+
+program.parse();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,7 +67,11 @@ program
         process.exit(1);
       }
 
-      const entries = sortEntries(registryResult.data);
+      if (registryResult.data.source === 'initialized') {
+        logger.info(`Initialized new MCP registry at ${paths.configFile}`);
+      }
+
+      const entries = sortEntries(registryResult.data.registry);
 
       if (entries.length === 0) {
         logger.info('No MCP entries found');
@@ -116,6 +120,14 @@ program
         process.exit(1);
       }
 
+      if (registryResult.data.source === 'initialized') {
+        logger.info(`Initialized new MCP registry at ${paths.configFile}`);
+      }
+
+      if (name in registryResult.data.registry) {
+        logger.warn(`MCP entry '${name}' already exists and will be overwritten.`);
+      }
+
       // Create backup
       const backupResult = await ensureBackup(paths);
       if (!backupResult.success) {
@@ -124,7 +136,7 @@ program
       }
 
       // Add entry and write
-      const newRegistry = addEntry(registryResult.data, name, externalEntry);
+      const newRegistry = addEntry(registryResult.data.registry, name, externalEntry);
       const writeResult = await writeRegistry(paths, newRegistry);
 
       if (!writeResult.success) {
@@ -165,7 +177,11 @@ program
       }
 
       // Check if entry exists
-      if (!(name in registryResult.data)) {
+      if (registryResult.data.source === 'initialized') {
+        logger.info(`Initialized new MCP registry at ${paths.configFile}`);
+      }
+
+      if (!(name in registryResult.data.registry)) {
         logger.warn(`MCP entry '${name}' not found`);
         return;
       }
@@ -178,7 +194,7 @@ program
       }
 
       // Remove entry and write
-      const newRegistry = removeEntry(registryResult.data, name);
+      const newRegistry = removeEntry(registryResult.data.registry, name);
       const writeResult = await writeRegistry(paths, newRegistry);
 
       if (!writeResult.success) {

--- a/src/infra/logger.ts
+++ b/src/infra/logger.ts
@@ -1,0 +1,25 @@
+import type { Logger } from '../types/index.js';
+
+export const createLogger = (verbose: boolean): Logger => {
+  const formatMessage = (level: string, message: string): string => `[${level}] ${message}`;
+
+  return {
+    debug: (message: string): void => {
+      if (verbose) {
+        console.log(formatMessage('DEBUG', message));
+      }
+    },
+
+    info: (message: string): void => {
+      console.log(formatMessage('INFO', message));
+    },
+
+    warn: (message: string): void => {
+      console.warn(formatMessage('WARN', message));
+    },
+
+    error: (message: string): void => {
+      console.error(formatMessage('ERROR', message));
+    }
+  };
+};

--- a/src/services/add-command.ts
+++ b/src/services/add-command.ts
@@ -1,0 +1,162 @@
+import type { McpEntry, Result } from '../types/index.js';
+
+export interface AddCommandOptions {
+  readonly transport?: string;
+  readonly env?: readonly string[];
+  readonly headers?: readonly string[];
+  readonly projectPath?: string;
+  readonly url?: string;
+  readonly command?: string;
+}
+
+export interface AddCommandInput {
+  readonly name: string;
+  readonly target?: string;
+  readonly commandArguments: readonly string[];
+  readonly options: AddCommandOptions;
+}
+
+export interface AddCommandError {
+  readonly message: string;
+}
+
+const splitKeyValue = (
+  value: string,
+  label: string
+): Result<[string, string], AddCommandError> => {
+  const separators = ['=', ':'];
+  const index = separators
+    .map(sep => value.indexOf(sep))
+    .filter(position => position >= 0)
+    .sort((a, b) => a - b)[0];
+
+  if (index === undefined) {
+    return {
+      success: false,
+      error: { message: `${label} must be in KEY=VALUE format` }
+    };
+  }
+
+  const key = value.slice(0, index).trim();
+  const raw = value.slice(index + 1).trim();
+
+  if (key.length === 0) {
+    return {
+      success: false,
+      error: { message: `${label} key must not be empty` }
+    };
+  }
+
+  return {
+    success: true,
+    data: [key, raw]
+  };
+};
+
+const toRecord = (
+  values: readonly string[] | undefined,
+  label: string
+): Result<Record<string, string>, AddCommandError> => {
+  const entries: Record<string, string> = {};
+
+  if (!values) {
+    return { success: true, data: entries };
+  }
+
+  for (const value of values) {
+    const parsed = splitKeyValue(value, label);
+    if (!parsed.success) {
+      return parsed;
+    }
+
+    const [key, val] = parsed.data;
+    entries[key] = val;
+  }
+
+  return { success: true, data: entries };
+};
+
+const normaliseTransport = (transport?: string): string => {
+  if (!transport || transport.length === 0) {
+    return 'stdio';
+  }
+
+  return transport.toLowerCase();
+};
+
+const isRemoteTransport = (transport: string): boolean => {
+  return transport !== 'stdio';
+};
+
+const hasEntries = (record: Record<string, string>): boolean => {
+  return Object.keys(record).length > 0;
+};
+
+export const buildEntryFromCli = (
+  input: AddCommandInput
+): Result<McpEntry, AddCommandError> => {
+  const transport = normaliseTransport(input.options.transport);
+  const envResult = toRecord(input.options.env, 'env');
+  if (!envResult.success) {
+    return envResult;
+  }
+
+  const headersResult = toRecord(input.options.headers, 'header');
+  if (!headersResult.success) {
+    return headersResult;
+  }
+
+  const envRecord = envResult.data;
+  const headersRecord = headersResult.data;
+
+  if (isRemoteTransport(transport)) {
+    const url = input.options.url ?? input.target;
+    if (!url) {
+      return {
+        success: false,
+        error: { message: `url is required for transport "${transport}"` }
+      };
+    }
+
+    const remoteEntry: McpEntry = {
+      type: transport,
+      transport,
+      url,
+      ...(hasEntries(headersRecord) ? { headers: headersRecord } : {}),
+      ...(hasEntries(envRecord) ? { env: envRecord } : {})
+    };
+
+    return {
+      success: true,
+      data: remoteEntry
+    };
+  }
+
+  const command = input.options.command ?? input.target;
+  if (!command || command.length === 0) {
+    return {
+      success: false,
+      error: { message: 'command is required when transport is stdio' }
+    };
+  }
+
+  const argsBase =
+    input.options.command !== undefined
+      ? [
+          ...(input.target ? [input.target] : []),
+          ...input.commandArguments
+        ]
+      : [...input.commandArguments];
+
+  const stdioEntry: McpEntry = {
+    command,
+    ...(argsBase.length > 0 ? { args: argsBase } : {}),
+    ...(hasEntries(envRecord) ? { env: envRecord } : {}),
+    ...(input.options.projectPath ? { project_path: input.options.projectPath } : {})
+  };
+
+  return {
+    success: true,
+    data: stdioEntry
+  };
+};

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -1,0 +1,98 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type { ConfigPaths, McpRegistry, McpConfig, Result, IOError } from '../types/index.js';
+
+export const resolveConfigPaths = (env: NodeJS.ProcessEnv): ConfigPaths => {
+  const configDir = env.MCP_CONFIG_DIR ?? join(homedir(), '.manage_mcp');
+  return {
+    configDir,
+    configFile: join(configDir, 'mcp.json'),
+    backupFile: join(configDir, 'mcp.json.bak')
+  };
+};
+
+export const readRegistry = async (paths: ConfigPaths): Promise<Result<McpRegistry, IOError>> => {
+  try {
+    const content = await fs.readFile(paths.configFile, 'utf8');
+    const config = JSON.parse(content) as McpConfig;
+    const registry = config.mcpServers || {};
+    return { success: true, data: registry };
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'code' in error) {
+      if (error.code === 'ENOENT') {
+        return { success: true, data: {} };
+      }
+      if (error.code === 'EACCES') {
+        return {
+          success: false,
+          error: {
+            type: 'PermissionDenied',
+            message: `Permission denied reading ${paths.configFile}`,
+            cause: error
+          }
+        };
+      }
+    }
+
+    if (error instanceof SyntaxError) {
+      return {
+        success: false,
+        error: {
+          type: 'InvalidJSON',
+          message: `Invalid JSON in ${paths.configFile}: ${error.message}`,
+          cause: error
+        }
+      };
+    }
+
+    return {
+      success: false,
+      error: {
+        type: 'Unknown',
+        message: `Failed to read ${paths.configFile}: ${error}`,
+        cause: error
+      }
+    };
+  }
+};
+
+export const writeRegistry = async (paths: ConfigPaths, registry: McpRegistry): Promise<Result<void, IOError>> => {
+  try {
+    await fs.mkdir(paths.configDir, { recursive: true });
+    const config: McpConfig = { mcpServers: registry };
+    const content = JSON.stringify(config, null, 2);
+    await fs.writeFile(paths.configFile, content, 'utf8');
+    return { success: true, data: undefined };
+  } catch (error: unknown) {
+    return {
+      success: false,
+      error: {
+        type: 'Unknown',
+        message: `Failed to write ${paths.configFile}: ${error}`,
+        cause: error
+      }
+    };
+  }
+};
+
+export const ensureBackup = async (paths: ConfigPaths): Promise<Result<void, IOError>> => {
+  try {
+    await fs.access(paths.configFile);
+    await fs.copyFile(paths.configFile, paths.backupFile);
+    return { success: true, data: undefined };
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return { success: true, data: undefined };
+    }
+
+    return {
+      success: false,
+      error: {
+        type: 'Unknown',
+        message: `Failed to create backup: ${error}`,
+        cause: error
+      }
+    };
+  }
+};

--- a/src/services/export-service.ts
+++ b/src/services/export-service.ts
@@ -1,0 +1,79 @@
+import { resolveConfigPaths, readRegistry } from './config-service.js';
+import { createLogger } from '../infra/logger.js';
+import { createClaudeCodeExporter } from './target-writers/claude-code-writer.js';
+import { createClaudeDesktopExporter } from './target-writers/claude-desktop-writer.js';
+import { createCursorExporter } from './target-writers/cursor-writer.js';
+import { createCodexExporter } from './target-writers/codex-writer.js';
+import type {
+  Result,
+  ExportError,
+  ExportSummary,
+  ExportOptions,
+  McpRegistry
+} from '../types/index.js';
+
+export interface ToolExporter {
+  readonly write: (registry: McpRegistry) => Promise<Result<void, ExportError>>;
+}
+
+export const resolveExporter = (tool: string): Result<ToolExporter, ExportError> => {
+  switch (tool) {
+    case 'ClaudeCode':
+      return { success: true, data: createClaudeCodeExporter() };
+    case 'ClaudeDesktop':
+      return { success: true, data: createClaudeDesktopExporter() };
+    case 'Cursor':
+      return { success: true, data: createCursorExporter() };
+    case 'Codex':
+      return { success: true, data: createCodexExporter() };
+    default:
+      return {
+        success: false,
+        error: {
+          type: 'Unknown',
+          message: `Unsupported tool: ${tool}`
+        }
+      };
+  }
+};
+
+export const exportMcpConfig = async (
+  tools: readonly string[],
+  options: ExportOptions
+): Promise<ExportSummary> => {
+  const logger = createLogger(false);
+  logger.info(`Exporting MCP entries to tools: ${tools.join(', ')}`);
+
+  const paths = resolveConfigPaths(options.env);
+  const registryResult = await readRegistry(paths);
+
+  if (!registryResult.success) {
+    logger.error(`Failed to read registry: ${registryResult.error.message}`);
+    throw new Error(registryResult.error.message);
+  }
+
+  const registry = registryResult.data.registry;
+  const updatedTools: string[] = [];
+
+  for (const tool of tools) {
+    const exporterResult = resolveExporter(tool);
+    if (!exporterResult.success) {
+      logger.error(exporterResult.error.message);
+      throw new Error(exporterResult.error.message);
+    }
+
+    const writeResult = await exporterResult.data.write(registry);
+    if (!writeResult.success) {
+      logger.error(writeResult.error.message);
+      throw new Error(writeResult.error.message);
+    }
+
+    updatedTools.push(tool);
+  }
+
+  logger.info(`Exported MCP entries to ${updatedTools.length} tool(s).`);
+
+  return {
+    updatedTools
+  };
+};

--- a/src/services/extract-service.ts
+++ b/src/services/extract-service.ts
@@ -1,0 +1,185 @@
+import { resolveConfigPaths, readRegistry, writeRegistry, ensureBackup } from './config-service.js';
+import { createLogger } from '../infra/logger.js';
+import { createInterface } from 'readline/promises';
+import { createClaudeCodeProfile } from './source-readers/claude-code.js';
+import { createClaudeDesktopProfile } from './source-readers/claude-desktop.js';
+import { createCursorProfile } from './source-readers/cursor.js';
+import { createCodexProfile } from './source-readers/codex.js';
+import type {
+  Result,
+  ExtractError,
+  ToolProfile,
+  ExtractOptions,
+  ExtractionSummary,
+  OverwriteDecision,
+  McpRegistry,
+  McpEntry,
+  MergeOutcome
+} from '../types/index.js';
+
+export const resolveProfile = (tool: string): Result<ToolProfile, ExtractError> => {
+  switch (tool) {
+    case 'ClaudeCode':
+      return { success: true, data: createClaudeCodeProfile() };
+    case 'ClaudeDesktop':
+      return { success: true, data: createClaudeDesktopProfile() };
+    case 'Cursor':
+      return { success: true, data: createCursorProfile() };
+    case 'Codex':
+      return { success: true, data: createCodexProfile() };
+    default:
+      return {
+        success: false,
+        error: {
+          type: 'ValidationFailed',
+          message: `Unsupported tool: ${tool}. Supported tools: ClaudeCode, ClaudeDesktop, Cursor, Codex`
+        }
+      };
+  }
+};
+
+export const promptOverwrite = async (
+  names: readonly string[],
+  force: boolean,
+  promptFn: (names: readonly string[]) => Promise<OverwriteDecision>
+): Promise<OverwriteDecision> => {
+  if (force) {
+    return names.reduce((acc, name) => ({ ...acc, [name]: true }), {});
+  }
+
+  return await promptFn(names);
+};
+
+export const mergeEntries = (
+  base: McpRegistry,
+  additions: McpRegistry,
+  decisions: OverwriteDecision
+): MergeOutcome => {
+  const conflicts: string[] = [];
+  const merged: Record<string, McpEntry> = { ...base };
+
+  Object.entries(additions).forEach(([name, entry]) => {
+    if (name in base) {
+      conflicts.push(name);
+      if (decisions[name]) {
+        merged[name] = entry;
+      }
+    } else {
+      merged[name] = entry;
+    }
+  });
+
+  return { merged, conflicts };
+};
+
+const defaultPromptFn = async (names: readonly string[]): Promise<OverwriteDecision> => {
+  if (names.length === 0) {
+    return {};
+  }
+
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  try {
+    const message = `The following entries already exist and may be overwritten: ${names.join(', ')}\nContinue? (y/N): `;
+    const answer = await rl.question(message);
+    const normalized = answer.trim().toLowerCase();
+    const accepted = normalized === 'y' || normalized === 'yes';
+
+    return names.reduce<OverwriteDecision>((acc, name) => ({ ...acc, [name]: accepted }), {});
+  } finally {
+    rl.close();
+  }
+};
+
+export const extractMcpConfig = async (
+  tool: string,
+  options: ExtractOptions,
+  promptFn: (names: readonly string[]) => Promise<OverwriteDecision> = defaultPromptFn
+): Promise<ExtractionSummary> => {
+  const logger = createLogger(false);
+
+  logger.info(`Extracting MCP configuration from ${tool}`);
+
+  // Resolve tool profile
+  const profileResult = resolveProfile(tool);
+  if (!profileResult.success) {
+    logger.error(profileResult.error.message);
+    throw new Error(profileResult.error.message);
+  }
+
+  const profile = profileResult.data;
+
+  // Read source configuration
+  const sourceResult = await profile.readSource();
+  if (!sourceResult.success) {
+    if (sourceResult.error.type === 'SourceMissing') {
+      logger.info(`No MCP entries found for ${tool} (source file not found)`);
+      return { tool, addedCount: 0, skippedEntries: [] };
+    }
+    logger.error(`Failed to read source: ${sourceResult.error.message}`);
+    throw new Error(sourceResult.error.message);
+  }
+
+  const sourceData = sourceResult.data;
+  logger.debug(`Found ${Object.keys(sourceData.entries).length} MCP entries in source`);
+
+  // Read existing registry
+  const paths = resolveConfigPaths(options.env);
+  const registryResult = await readRegistry(paths);
+  if (!registryResult.success) {
+    logger.error(`Failed to read registry: ${registryResult.error.message}`);
+    throw new Error(registryResult.error.message);
+  }
+
+  if (registryResult.data.source === 'initialized') {
+    logger.info(`Initialized new MCP registry at ${paths.configFile}`);
+  }
+
+  // Merge entries and handle conflicts
+  const tempMerge = mergeEntries(registryResult.data.registry, sourceData.entries, {});
+  let decisions: OverwriteDecision = {};
+
+  if (tempMerge.conflicts.length > 0) {
+    decisions = await promptOverwrite(tempMerge.conflicts, options.force, promptFn);
+  }
+
+  const finalMerge = mergeEntries(registryResult.data.registry, sourceData.entries, decisions);
+  const skippedEntries = tempMerge.conflicts.filter(name => !decisions[name]);
+
+  if (skippedEntries.length > 0) {
+    skippedEntries.forEach(name => {
+      logger.warn(`Skipped overwriting existing entry: ${name}`);
+    });
+  }
+
+  // Create backup and write registry
+  const backupResult = await ensureBackup(paths);
+  if (!backupResult.success) {
+    logger.error(`Failed to create backup: ${backupResult.error.message}`);
+    throw new Error(backupResult.error.message);
+  }
+
+  const writeResult = await writeRegistry(paths, finalMerge.merged);
+  if (!writeResult.success) {
+    logger.error(`Failed to write registry: ${writeResult.error.message}`);
+    throw new Error(writeResult.error.message);
+  }
+
+  const addedCount = Object.keys(sourceData.entries).length - skippedEntries.length;
+  logger.info(`Successfully added ${addedCount} MCP entries from ${tool}`);
+
+  Object.entries(sourceData.entries).forEach(([name, entry]) => {
+    if (!skippedEntries.includes(name)) {
+      logger.debug(`Added: ${name} (command: ${entry.command})`);
+    }
+  });
+
+  return {
+    tool,
+    addedCount,
+    skippedEntries
+  };
+};

--- a/src/services/import-service.ts
+++ b/src/services/import-service.ts
@@ -7,17 +7,17 @@ import { createCursorProfile } from './source-readers/cursor.js';
 import { createCodexProfile } from './source-readers/codex.js';
 import type {
   Result,
-  ExtractError,
+  ImportError,
   ToolProfile,
-  ExtractOptions,
-  ExtractionSummary,
+  ImportOptions,
+  ImportSummary,
   OverwriteDecision,
   McpRegistry,
   McpEntry,
   MergeOutcome
 } from '../types/index.js';
 
-export const resolveProfile = (tool: string): Result<ToolProfile, ExtractError> => {
+export const resolveProfile = (tool: string): Result<ToolProfile, ImportError> => {
   switch (tool) {
     case 'ClaudeCode':
       return { success: true, data: createClaudeCodeProfile() };
@@ -94,14 +94,14 @@ const defaultPromptFn = async (names: readonly string[]): Promise<OverwriteDecis
   }
 };
 
-export const extractMcpConfig = async (
+export const importMcpConfig = async (
   tool: string,
-  options: ExtractOptions,
+  options: ImportOptions,
   promptFn: (names: readonly string[]) => Promise<OverwriteDecision> = defaultPromptFn
-): Promise<ExtractionSummary> => {
+): Promise<ImportSummary> => {
   const logger = createLogger(false);
 
-  logger.info(`Extracting MCP configuration from ${tool}`);
+  logger.info(`Importing MCP configuration from ${tool}`);
 
   // Resolve tool profile
   const profileResult = resolveProfile(tool);

--- a/src/services/mcp-service.ts
+++ b/src/services/mcp-service.ts
@@ -1,0 +1,25 @@
+import type { McpRegistry, McpEntry } from '../types/index.js';
+
+export interface RegistryEntry {
+  readonly name: string;
+  readonly entry: McpEntry;
+}
+
+export const sortEntries = (registry: McpRegistry): readonly RegistryEntry[] => {
+  return Object.entries(registry)
+    .map(([name, entry]) => ({ name, entry }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+export const addEntry = (registry: McpRegistry, name: string, entry: McpEntry): McpRegistry => {
+  return {
+    ...registry,
+    [name]: entry
+  };
+};
+
+export const removeEntry = (registry: McpRegistry, name: string): McpRegistry => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { [name]: _, ...newRegistry } = registry;
+  return newRegistry;
+};

--- a/src/services/source-readers/claude-code.ts
+++ b/src/services/source-readers/claude-code.ts
@@ -1,0 +1,118 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type { ToolProfile, Result, ExtractError, SourceData, McpRegistry, McpEntry } from '../../types/index.js';
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const isMcpEntry = (value: unknown): value is McpEntry => {
+  if (!isRecord(value) || typeof value.command !== 'string' || value.command.length === 0) {
+    return false;
+  }
+
+  if (value.project_path !== undefined && typeof value.project_path !== 'string') {
+    return false;
+  }
+
+  return true;
+};
+
+const extractProjectName = (projectPath: string): string => {
+  const pathParts = projectPath.split('/');
+  const projectName = pathParts[pathParts.length - 1] || 'project';
+  return projectName.replace(/[^a-zA-Z0-9]/g, '_');
+};
+
+export const createClaudeCodeProfile = (): ToolProfile => {
+  const mapToRegistry = (data: unknown): Result<McpRegistry, ExtractError> => {
+    if (!isRecord(data)) {
+      return { success: true, data: {} };
+    }
+
+    const registry: Record<string, McpEntry> = {};
+
+    // Extract from top-level mcpServers
+    if (isRecord(data.mcpServers)) {
+      Object.entries(data.mcpServers).forEach(([name, entry]) => {
+        if (isMcpEntry(entry)) {
+          registry[name] = entry;
+        }
+      });
+    }
+
+    // Extract from project mcpServers
+    if (isRecord(data.projects)) {
+      Object.entries(data.projects).forEach(([projectPath, projectData]) => {
+        if (isRecord(projectData) && isRecord(projectData.mcpServers)) {
+          const projectName = extractProjectName(projectPath);
+          Object.entries(projectData.mcpServers).forEach(([name, entry]) => {
+            if (isMcpEntry(entry)) {
+              const sanitizedName = name.replace(/[^a-zA-Z0-9-_]/g, '_');
+              const compositeName = `project[${projectName}].${sanitizedName}`;
+              const enrichedEntry: McpEntry = { ...(entry as McpEntry), project_path: projectPath };
+              (registry as Record<string, McpEntry>)[compositeName] = enrichedEntry;
+            }
+          });
+        }
+      });
+    }
+
+    return { success: true, data: registry };
+  };
+
+  const readSource = async (): Promise<Result<SourceData, ExtractError>> => {
+    const filePath = join(homedir(), '.claude.json');
+
+    try {
+      const content = await fs.readFile(filePath, 'utf8');
+      const parsed = JSON.parse(content);
+      const registryResult = mapToRegistry(parsed);
+
+      if (!registryResult.success) {
+        return registryResult;
+      }
+
+      return {
+        success: true,
+        data: {
+          entries: registryResult.data,
+          promptRequired: Object.keys(registryResult.data)
+        }
+      };
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        return {
+          success: false,
+          error: {
+            type: 'SourceMissing',
+            message: `ClaudeCode config file not found at ${filePath}`
+          }
+        };
+      }
+
+      if (error instanceof SyntaxError) {
+        return {
+          success: false,
+          error: {
+            type: 'ParseFailed',
+            message: `Invalid JSON in ${filePath}: ${error.message}`,
+            cause: error
+          }
+        };
+      }
+
+      return {
+        success: false,
+        error: {
+          type: 'IOError',
+          message: `Failed to read ${filePath}: ${error}`,
+          cause: error
+        }
+      };
+    }
+  };
+
+  return { readSource, mapToRegistry };
+};

--- a/src/services/source-readers/claude-desktop.ts
+++ b/src/services/source-readers/claude-desktop.ts
@@ -1,0 +1,92 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type { ToolProfile, Result, ExtractError, SourceData, McpRegistry, McpEntry } from '../../types/index.js';
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const isMcpEntry = (value: unknown): value is McpEntry => {
+  if (!isRecord(value) || typeof value.command !== 'string' || value.command.length === 0) {
+    return false;
+  }
+
+  if (value.project_path !== undefined && typeof value.project_path !== 'string') {
+    return false;
+  }
+
+  return true;
+};
+
+export const createClaudeDesktopProfile = (): ToolProfile => {
+  const mapToRegistry = (data: unknown): Result<McpRegistry, ExtractError> => {
+    if (!isRecord(data) || !isRecord(data.mcpServers)) {
+      return { success: true, data: {} };
+    }
+
+    const registry: Record<string, McpEntry> = {};
+
+    Object.entries(data.mcpServers).forEach(([name, entry]) => {
+      if (isMcpEntry(entry)) {
+        registry[name] = entry;
+      }
+    });
+
+    return { success: true, data: registry };
+  };
+
+  const readSource = async (): Promise<Result<SourceData, ExtractError>> => {
+    const filePath = join(homedir(), 'Library/Application Support/Claude/claude_desktop_config.json');
+
+    try {
+      const content = await fs.readFile(filePath, 'utf8');
+      const parsed = JSON.parse(content);
+      const registryResult = mapToRegistry(parsed);
+
+      if (!registryResult.success) {
+        return registryResult;
+      }
+
+      return {
+        success: true,
+        data: {
+          entries: registryResult.data,
+          promptRequired: Object.keys(registryResult.data)
+        }
+      };
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        return {
+          success: false,
+          error: {
+            type: 'SourceMissing',
+            message: `ClaudeDesktop config file not found at ${filePath}`
+          }
+        };
+      }
+
+      if (error instanceof SyntaxError) {
+        return {
+          success: false,
+          error: {
+            type: 'ParseFailed',
+            message: `Invalid JSON in ${filePath}: ${error.message}`,
+            cause: error
+          }
+        };
+      }
+
+      return {
+        success: false,
+        error: {
+          type: 'IOError',
+          message: `Failed to read ${filePath}: ${error}`,
+          cause: error
+        }
+      };
+    }
+  };
+
+  return { readSource, mapToRegistry };
+};

--- a/src/services/source-readers/claude-desktop.ts
+++ b/src/services/source-readers/claude-desktop.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import type { ToolProfile, Result, ExtractError, SourceData, McpRegistry, McpEntry } from '../../types/index.js';
+import type { ToolProfile, Result, ImportError, SourceData, McpRegistry, McpEntry } from '../../types/index.js';
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -20,28 +20,31 @@ const isMcpEntry = (value: unknown): value is McpEntry => {
 };
 
 export const createClaudeDesktopProfile = (): ToolProfile => {
-  const mapToRegistry = (data: unknown): Result<McpRegistry, ExtractError> => {
-    if (!isRecord(data) || !isRecord(data.mcpServers)) {
+  const mapToRegistry = (data: unknown): Result<McpRegistry, ImportError> => {
+    if (!isRecord(data)) {
       return { success: true, data: {} };
     }
 
     const registry: Record<string, McpEntry> = {};
 
-    Object.entries(data.mcpServers).forEach(([name, entry]) => {
-      if (isMcpEntry(entry)) {
-        registry[name] = entry;
+    const servers = data.mcpServers;
+    if (isRecord(servers)) {
+      for (const [name, entry] of Object.entries(servers)) {
+        if (isMcpEntry(entry)) {
+          registry[name] = entry;
+        }
       }
-    });
+    }
 
     return { success: true, data: registry };
   };
 
-  const readSource = async (): Promise<Result<SourceData, ExtractError>> => {
+  const readSource = async (): Promise<Result<SourceData, ImportError>> => {
     const filePath = join(homedir(), 'Library/Application Support/Claude/claude_desktop_config.json');
 
     try {
       const content = await fs.readFile(filePath, 'utf8');
-      const parsed = JSON.parse(content);
+      const parsed: unknown = JSON.parse(content);
       const registryResult = mapToRegistry(parsed);
 
       if (!registryResult.success) {

--- a/src/services/source-readers/codex.ts
+++ b/src/services/source-readers/codex.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { parse as parseToml } from '@iarna/toml';
-import type { ToolProfile, Result, ExtractError, SourceData, McpRegistry, McpEntry } from '../../types/index.js';
+import type { ToolProfile, Result, ImportError, SourceData, McpRegistry, McpEntry } from '../../types/index.js';
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -21,28 +21,31 @@ const isMcpEntry = (value: unknown): value is McpEntry => {
 };
 
 export const createCodexProfile = (): ToolProfile => {
-  const mapToRegistry = (data: unknown): Result<McpRegistry, ExtractError> => {
-    if (!isRecord(data) || !isRecord(data.mcp_servers)) {
+  const mapToRegistry = (data: unknown): Result<McpRegistry, ImportError> => {
+    if (!isRecord(data)) {
       return { success: true, data: {} };
     }
 
     const registry: Record<string, McpEntry> = {};
 
-    Object.entries(data.mcp_servers).forEach(([name, entry]) => {
-      if (isMcpEntry(entry)) {
-        registry[name] = entry;
+    const servers = data.mcp_servers;
+    if (isRecord(servers)) {
+      for (const [name, entry] of Object.entries(servers)) {
+        if (isMcpEntry(entry)) {
+          registry[name] = entry;
+        }
       }
-    });
+    }
 
     return { success: true, data: registry };
   };
 
-  const readSource = async (): Promise<Result<SourceData, ExtractError>> => {
+  const readSource = async (): Promise<Result<SourceData, ImportError>> => {
     const filePath = join(homedir(), '.codex/config.toml');
 
     try {
       const content = await fs.readFile(filePath, 'utf8');
-      const parsed = parseToml(content);
+      const parsed: unknown = parseToml(content);
       const registryResult = mapToRegistry(parsed);
 
       if (!registryResult.success) {

--- a/src/services/source-readers/codex.ts
+++ b/src/services/source-readers/codex.ts
@@ -1,0 +1,93 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { parse as parseToml } from '@iarna/toml';
+import type { ToolProfile, Result, ExtractError, SourceData, McpRegistry, McpEntry } from '../../types/index.js';
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const isMcpEntry = (value: unknown): value is McpEntry => {
+  if (!isRecord(value) || typeof value.command !== 'string' || value.command.length === 0) {
+    return false;
+  }
+
+  if (value.project_path !== undefined && typeof value.project_path !== 'string') {
+    return false;
+  }
+
+  return true;
+};
+
+export const createCodexProfile = (): ToolProfile => {
+  const mapToRegistry = (data: unknown): Result<McpRegistry, ExtractError> => {
+    if (!isRecord(data) || !isRecord(data.mcp_servers)) {
+      return { success: true, data: {} };
+    }
+
+    const registry: Record<string, McpEntry> = {};
+
+    Object.entries(data.mcp_servers).forEach(([name, entry]) => {
+      if (isMcpEntry(entry)) {
+        registry[name] = entry;
+      }
+    });
+
+    return { success: true, data: registry };
+  };
+
+  const readSource = async (): Promise<Result<SourceData, ExtractError>> => {
+    const filePath = join(homedir(), '.codex/config.toml');
+
+    try {
+      const content = await fs.readFile(filePath, 'utf8');
+      const parsed = parseToml(content);
+      const registryResult = mapToRegistry(parsed);
+
+      if (!registryResult.success) {
+        return registryResult;
+      }
+
+      return {
+        success: true,
+        data: {
+          entries: registryResult.data,
+          promptRequired: Object.keys(registryResult.data)
+        }
+      };
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        return {
+          success: false,
+          error: {
+            type: 'SourceMissing',
+            message: `Codex config file not found at ${filePath}`
+          }
+        };
+      }
+
+      if (error instanceof Error && error.message.includes('TOML')) {
+        return {
+          success: false,
+          error: {
+            type: 'ParseFailed',
+            message: `Invalid TOML in ${filePath}: ${error.message}`,
+            cause: error
+          }
+        };
+      }
+
+      return {
+        success: false,
+        error: {
+          type: 'IOError',
+          message: `Failed to read ${filePath}: ${error}`,
+          cause: error
+        }
+      };
+    }
+  };
+
+  return { readSource, mapToRegistry };
+};

--- a/src/services/source-readers/cursor.ts
+++ b/src/services/source-readers/cursor.ts
@@ -1,0 +1,92 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type { ToolProfile, Result, ExtractError, SourceData, McpRegistry, McpEntry } from '../../types/index.js';
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const isMcpEntry = (value: unknown): value is McpEntry => {
+  if (!isRecord(value) || typeof value.command !== 'string' || value.command.length === 0) {
+    return false;
+  }
+
+  if (value.project_path !== undefined && typeof value.project_path !== 'string') {
+    return false;
+  }
+
+  return true;
+};
+
+export const createCursorProfile = (): ToolProfile => {
+  const mapToRegistry = (data: unknown): Result<McpRegistry, ExtractError> => {
+    if (!isRecord(data) || !isRecord(data.mcpServers)) {
+      return { success: true, data: {} };
+    }
+
+    const registry: Record<string, McpEntry> = {};
+
+    Object.entries(data.mcpServers).forEach(([name, entry]) => {
+      if (isMcpEntry(entry)) {
+        registry[name] = entry;
+      }
+    });
+
+    return { success: true, data: registry };
+  };
+
+  const readSource = async (): Promise<Result<SourceData, ExtractError>> => {
+    const filePath = join(homedir(), '.cursor/mcp.json');
+
+    try {
+      const content = await fs.readFile(filePath, 'utf8');
+      const parsed = JSON.parse(content);
+      const registryResult = mapToRegistry(parsed);
+
+      if (!registryResult.success) {
+        return registryResult;
+      }
+
+      return {
+        success: true,
+        data: {
+          entries: registryResult.data,
+          promptRequired: Object.keys(registryResult.data)
+        }
+      };
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        return {
+          success: false,
+          error: {
+            type: 'SourceMissing',
+            message: `Cursor config file not found at ${filePath}`
+          }
+        };
+      }
+
+      if (error instanceof SyntaxError) {
+        return {
+          success: false,
+          error: {
+            type: 'ParseFailed',
+            message: `Invalid JSON in ${filePath}: ${error.message}`,
+            cause: error
+          }
+        };
+      }
+
+      return {
+        success: false,
+        error: {
+          type: 'IOError',
+          message: `Failed to read ${filePath}: ${error}`,
+          cause: error
+        }
+      };
+    }
+  };
+
+  return { readSource, mapToRegistry };
+};

--- a/src/services/target-writers/claude-code-writer.ts
+++ b/src/services/target-writers/claude-code-writer.ts
@@ -1,0 +1,122 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type { McpRegistry, Result, ExportError, McpEntry } from '../../types/index.js';
+
+const CLAUDE_CODE_PATH = join(homedir(), '.claude.json');
+
+const stripProjectMetadata = (entry: McpEntry): Record<string, unknown> => {
+  const { project_path: _projectPath, ...rest } = entry;
+  return { ...rest } as Record<string, unknown>;
+};
+
+const deriveProjectName = (projectPath: string): string => {
+  const segments = projectPath.split('/');
+  const projectName = segments[segments.length - 1] || projectPath;
+  return projectName.replace(/[^a-zA-Z0-9-_]/g, '_');
+};
+
+const getMcpName = (entryName: string, projectName: string): string => {
+  const marker = `project[${projectName}].`;
+  if (entryName.startsWith(marker)) {
+    return entryName.slice(marker.length);
+  }
+  const lastSeparator = entryName.lastIndexOf('.');
+  if (lastSeparator >= 0 && lastSeparator < entryName.length - 1) {
+    return entryName.slice(lastSeparator + 1);
+  }
+  return entryName;
+};
+
+export interface ClaudeCodeExporter {
+  readonly write: (registry: McpRegistry) => Promise<Result<void, ExportError>>;
+}
+
+export const createClaudeCodeExporter = (): ClaudeCodeExporter => {
+  const write = async (registry: McpRegistry): Promise<Result<void, ExportError>> => {
+    let existing: Record<string, unknown> = {};
+
+    try {
+      const content = await fs.readFile(CLAUDE_CODE_PATH, 'utf8');
+      existing = JSON.parse(content) as Record<string, unknown>;
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        existing = {};
+      } else if (error instanceof SyntaxError) {
+        return {
+          success: false,
+          error: {
+            type: 'ParseFailed',
+            message: `Invalid JSON in ${CLAUDE_CODE_PATH}: ${error.message}`,
+            cause: error
+          }
+        };
+      } else if (error !== null && error !== undefined) {
+        return {
+          success: false,
+          error: {
+            type: 'IOError',
+            message: `Failed to read ${CLAUDE_CODE_PATH}: ${error}`,
+            cause: error
+          }
+        };
+      }
+    }
+
+    const globalEntries: Record<string, unknown> = {};
+    const projectGroups: Record<string, Record<string, unknown>> = {};
+
+    for (const [entryName, entry] of Object.entries(registry)) {
+      const { project_path: projectPath } = entry;
+      if (projectPath) {
+        const normalizedPath = projectPath;
+        const projectName = deriveProjectName(normalizedPath);
+        const mcpName = getMcpName(entryName, projectName);
+        if (!projectGroups[normalizedPath]) {
+          projectGroups[normalizedPath] = {};
+        }
+        projectGroups[normalizedPath][mcpName] = stripProjectMetadata(entry);
+      } else {
+        globalEntries[entryName] = stripProjectMetadata(entry);
+      }
+    }
+
+    const updated: Record<string, unknown> = {
+      ...existing,
+      mcpServers: globalEntries
+    };
+
+    if (Object.keys(projectGroups).length > 0) {
+      const projectsSection = { ...(existing.projects as Record<string, unknown> | undefined) };
+
+      for (const [path, entries] of Object.entries(projectGroups)) {
+        const projectName = deriveProjectName(path);
+        const currentProject = (projectsSection?.[path] as Record<string, unknown>) ?? {
+          name: projectName
+        };
+        projectsSection[path] = {
+          ...currentProject,
+          mcpServers: entries
+        };
+      }
+
+      updated.projects = projectsSection;
+    }
+
+    try {
+      await fs.writeFile(CLAUDE_CODE_PATH, JSON.stringify(updated, null, 2), 'utf8');
+      return { success: true, data: undefined };
+    } catch (error: unknown) {
+      return {
+        success: false,
+        error: {
+          type: 'IOError',
+          message: `Failed to write ${CLAUDE_CODE_PATH}: ${error}`,
+          cause: error
+        }
+      };
+    }
+  };
+
+  return { write };
+};

--- a/src/services/target-writers/claude-desktop-writer.ts
+++ b/src/services/target-writers/claude-desktop-writer.ts
@@ -1,0 +1,76 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type { McpRegistry, Result, ExportError, McpEntry } from '../../types/index.js';
+
+const CLAUDE_DESKTOP_PATH = join(homedir(), 'Library/Application Support/Claude/claude_desktop_config.json');
+
+const stripProjectMetadata = (entry: McpEntry): Record<string, unknown> => {
+  const { project_path: _projectPath, ...rest } = entry;
+  return { ...rest } as Record<string, unknown>;
+};
+
+export interface ClaudeDesktopExporter {
+  readonly write: (registry: McpRegistry) => Promise<Result<void, ExportError>>;
+}
+
+export const createClaudeDesktopExporter = (): ClaudeDesktopExporter => {
+  const write = async (registry: McpRegistry): Promise<Result<void, ExportError>> => {
+    let existing: Record<string, unknown> = {};
+
+    try {
+      const content = await fs.readFile(CLAUDE_DESKTOP_PATH, 'utf8');
+      existing = JSON.parse(content) as Record<string, unknown>;
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        existing = {};
+      } else if (error instanceof SyntaxError) {
+        return {
+          success: false,
+          error: {
+            type: 'ParseFailed',
+            message: `Invalid JSON in ${CLAUDE_DESKTOP_PATH}: ${error.message}`,
+            cause: error
+          }
+        };
+      } else if (error !== null && error !== undefined) {
+        return {
+          success: false,
+          error: {
+            type: 'IOError',
+            message: `Failed to read ${CLAUDE_DESKTOP_PATH}: ${error}`,
+            cause: error
+          }
+        };
+      }
+    }
+
+    const globalEntries: Record<string, unknown> = {};
+    for (const [name, entry] of Object.entries(registry)) {
+      if (!entry.project_path) {
+        globalEntries[name] = stripProjectMetadata(entry);
+      }
+    }
+
+    const updated = {
+      ...existing,
+      mcpServers: globalEntries
+    };
+
+    try {
+      await fs.writeFile(CLAUDE_DESKTOP_PATH, JSON.stringify(updated, null, 2), 'utf8');
+      return { success: true, data: undefined };
+    } catch (error: unknown) {
+      return {
+        success: false,
+        error: {
+          type: 'IOError',
+          message: `Failed to write ${CLAUDE_DESKTOP_PATH}: ${error}`,
+          cause: error
+        }
+      };
+    }
+  };
+
+  return { write };
+};

--- a/src/services/target-writers/codex-writer.ts
+++ b/src/services/target-writers/codex-writer.ts
@@ -1,0 +1,79 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { parse as parseToml, stringify as stringifyToml } from '@iarna/toml';
+import type { McpRegistry, Result, ExportError, McpEntry } from '../../types/index.js';
+
+const CODEX_PATH = join(homedir(), '.codex/config.toml');
+
+const stripProjectMetadata = (entry: McpEntry): Record<string, unknown> => {
+  const { project_path: _projectPath, ...rest } = entry;
+  return { ...rest } as Record<string, unknown>;
+};
+
+export interface CodexExporter {
+  readonly write: (registry: McpRegistry) => Promise<Result<void, ExportError>>;
+}
+
+export const createCodexExporter = (): CodexExporter => {
+  const write = async (registry: McpRegistry): Promise<Result<void, ExportError>> => {
+    let existing: Record<string, unknown> = {};
+
+    try {
+      const content = await fs.readFile(CODEX_PATH, 'utf8');
+      existing = parseToml(content) as Record<string, unknown>;
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        existing = {};
+      } else if (error instanceof Error && error.message) {
+        return {
+          success: false,
+          error: {
+            type: 'ParseFailed',
+            message: `Invalid TOML in ${CODEX_PATH}: ${error.message}`,
+            cause: error
+          }
+        };
+      } else if (error !== null && error !== undefined) {
+        return {
+          success: false,
+          error: {
+            type: 'IOError',
+            message: `Failed to read ${CODEX_PATH}: ${error}`,
+            cause: error
+          }
+        };
+      }
+    }
+
+    const globalEntries: Record<string, unknown> = {};
+    for (const [name, entry] of Object.entries(registry)) {
+      if (!entry.project_path) {
+        globalEntries[name] = stripProjectMetadata(entry);
+      }
+    }
+
+    const updated: Record<string, unknown> = {
+      ...existing,
+      mcp_servers: globalEntries
+    };
+
+    try {
+      type TomlInput = Parameters<typeof stringifyToml>[0];
+      const content = stringifyToml(updated as unknown as TomlInput);
+      await fs.writeFile(CODEX_PATH, content, 'utf8');
+      return { success: true, data: undefined };
+    } catch (error: unknown) {
+      return {
+        success: false,
+        error: {
+          type: 'IOError',
+          message: `Failed to write ${CODEX_PATH}: ${error}`,
+          cause: error
+        }
+      };
+    }
+  };
+
+  return { write };
+};

--- a/src/services/target-writers/cursor-writer.ts
+++ b/src/services/target-writers/cursor-writer.ts
@@ -1,0 +1,76 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type { McpRegistry, Result, ExportError, McpEntry } from '../../types/index.js';
+
+const CURSOR_PATH = join(homedir(), '.cursor/mcp.json');
+
+const stripProjectMetadata = (entry: McpEntry): Record<string, unknown> => {
+  const { project_path: _projectPath, ...rest } = entry;
+  return { ...rest } as Record<string, unknown>;
+};
+
+export interface CursorExporter {
+  readonly write: (registry: McpRegistry) => Promise<Result<void, ExportError>>;
+}
+
+export const createCursorExporter = (): CursorExporter => {
+  const write = async (registry: McpRegistry): Promise<Result<void, ExportError>> => {
+    let existing: Record<string, unknown> = {};
+
+    try {
+      const content = await fs.readFile(CURSOR_PATH, 'utf8');
+      existing = JSON.parse(content) as Record<string, unknown>;
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        existing = {};
+      } else if (error instanceof SyntaxError) {
+        return {
+          success: false,
+          error: {
+            type: 'ParseFailed',
+            message: `Invalid JSON in ${CURSOR_PATH}: ${error.message}`,
+            cause: error
+          }
+        };
+      } else if (error !== null && error !== undefined) {
+        return {
+          success: false,
+          error: {
+            type: 'IOError',
+            message: `Failed to read ${CURSOR_PATH}: ${error}`,
+            cause: error
+          }
+        };
+      }
+    }
+
+    const globalEntries: Record<string, unknown> = {};
+    for (const [name, entry] of Object.entries(registry)) {
+      if (!entry.project_path) {
+        globalEntries[name] = stripProjectMetadata(entry);
+      }
+    }
+
+    const updated = {
+      ...existing,
+      mcpServers: globalEntries
+    };
+
+    try {
+      await fs.writeFile(CURSOR_PATH, JSON.stringify(updated, null, 2), 'utf8');
+      return { success: true, data: undefined };
+    } catch (error: unknown) {
+      return {
+        success: false,
+        error: {
+          type: 'IOError',
+          message: `Failed to write ${CURSOR_PATH}: ${error}`,
+          cause: error
+        }
+      };
+    }
+  };
+
+  return { write };
+};

--- a/src/services/validation.ts
+++ b/src/services/validation.ts
@@ -1,0 +1,50 @@
+import type { McpEntry, ValidationError } from '../types/index.js';
+
+export const validateEntry = (name: string, entry: McpEntry): readonly ValidationError[] => {
+  const errors: ValidationError[] = [];
+
+  if (entry.command === undefined) {
+    errors.push({ path: `${name}.command`, reason: 'command is required' });
+  } else if (typeof entry.command !== 'string') {
+    errors.push({ path: `${name}.command`, reason: 'command must be a string' });
+  } else if (entry.command === '') {
+    errors.push({ path: `${name}.command`, reason: 'command cannot be empty' });
+  }
+
+  if (entry.args !== undefined) {
+    if (!Array.isArray(entry.args)) {
+      errors.push({ path: `${name}.args`, reason: 'args must be an array' });
+    } else {
+      entry.args.forEach((arg, index) => {
+        if (typeof arg !== 'string') {
+          errors.push({ path: `${name}.args[${index}]`, reason: 'args elements must be strings' });
+        }
+      });
+    }
+  }
+
+  if (entry.env !== undefined) {
+    if (typeof entry.env !== 'object' || entry.env === null || Array.isArray(entry.env)) {
+      errors.push({ path: `${name}.env`, reason: 'env must be an object' });
+    } else {
+      Object.entries(entry.env).forEach(([key, value]) => {
+        if (typeof value !== 'string') {
+          errors.push({ path: `${name}.env.${key}`, reason: 'env values must be strings' });
+        }
+      });
+    }
+  }
+
+  return errors;
+};
+
+export const validateMcpRegistry = (registry: Record<string, McpEntry>): readonly ValidationError[] => {
+  const allErrors: ValidationError[] = [];
+
+  Object.entries(registry).forEach(([name, entry]) => {
+    const entryErrors = validateEntry(name, entry);
+    allErrors.push(...entryErrors);
+  });
+
+  return allErrors;
+};

--- a/src/services/validation.ts
+++ b/src/services/validation.ts
@@ -3,8 +3,13 @@ import type { McpEntry, ValidationError } from '../types/index.js';
 export const validateEntry = (name: string, entry: McpEntry): readonly ValidationError[] => {
   const errors: ValidationError[] = [];
 
+  const transport = entry.transport ?? entry.type;
+  const isRemoteTransport = transport === 'sse' || transport === 'http';
+
   if (entry.command === undefined) {
-    errors.push({ path: `${name}.command`, reason: 'command is required' });
+    if (!isRemoteTransport) {
+      errors.push({ path: `${name}.command`, reason: 'command is required' });
+    }
   } else if (typeof entry.command !== 'string') {
     errors.push({ path: `${name}.command`, reason: 'command must be a string' });
   } else if (entry.command === '') {
@@ -30,6 +35,26 @@ export const validateEntry = (name: string, entry: McpEntry): readonly Validatio
       Object.entries(entry.env).forEach(([key, value]) => {
         if (typeof value !== 'string') {
           errors.push({ path: `${name}.env.${key}`, reason: 'env values must be strings' });
+        }
+      });
+    }
+  }
+
+  if (entry.url !== undefined) {
+    if (typeof entry.url !== 'string' || entry.url === '') {
+      errors.push({ path: `${name}.url`, reason: 'url must be a non-empty string' });
+    }
+  } else if (isRemoteTransport) {
+    errors.push({ path: `${name}.url`, reason: `url is required for transport "${transport}"` });
+  }
+
+  if (entry.headers !== undefined) {
+    if (typeof entry.headers !== 'object' || entry.headers === null || Array.isArray(entry.headers)) {
+      errors.push({ path: `${name}.headers`, reason: 'headers must be an object' });
+    } else {
+      Object.entries(entry.headers).forEach(([key, value]) => {
+        if (typeof value !== 'string') {
+          errors.push({ path: `${name}.headers.${key}`, reason: 'header values must be strings' });
         }
       });
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,44 @@
+export interface McpEntry {
+  readonly command: string;
+  readonly args?: readonly string[];
+  readonly type?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly transport?: string;
+  readonly capabilities?: unknown;
+}
+
+export type McpRegistry = Readonly<Record<string, McpEntry>>;
+
+export interface McpConfig {
+  readonly mcpServers: McpRegistry;
+}
+
+export interface ConfigPaths {
+  readonly configFile: string;
+  readonly backupFile: string;
+  readonly configDir: string;
+}
+
+export interface ValidationError {
+  readonly path: string;
+  readonly reason: string;
+}
+
+export type Result<T, E> =
+  | { readonly success: true; readonly data: T }
+  | { readonly success: false; readonly error: E };
+
+export interface IOError {
+  readonly type: 'FileNotFound' | 'PermissionDenied' | 'InvalidJSON' | 'Unknown';
+  readonly message: string;
+  readonly cause?: unknown;
+}
+
+export type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
+
+export interface Logger {
+  readonly debug: (message: string) => void;
+  readonly info: (message: string) => void;
+  readonly warn: (message: string) => void;
+  readonly error: (message: string) => void;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,10 +49,10 @@ export interface RegistryLoad {
   readonly source: 'existing' | 'initialized';
 }
 
-export type ExtractErrorType = 'SourceMissing' | 'ParseFailed' | 'ValidationFailed' | 'IOError';
+export type ImportErrorType = 'SourceMissing' | 'ParseFailed' | 'ValidationFailed' | 'IOError';
 
-export interface ExtractError {
-  readonly type: ExtractErrorType;
+export interface ImportError {
+  readonly type: ImportErrorType;
   readonly message: string;
   readonly cause?: unknown;
 }
@@ -63,11 +63,11 @@ export interface SourceData {
 }
 
 export interface ToolProfile {
-  readonly readSource: () => Promise<Result<SourceData, ExtractError>>;
-  readonly mapToRegistry: (data: unknown) => Result<McpRegistry, ExtractError>;
+  readonly readSource: () => Promise<Result<SourceData, ImportError>>;
+  readonly mapToRegistry: (data: unknown) => Result<McpRegistry, ImportError>;
 }
 
-export interface ExtractionSummary {
+export interface ImportSummary {
   readonly addedCount: number;
   readonly skippedEntries: readonly string[];
   readonly tool: string;
@@ -77,7 +77,7 @@ export interface OverwriteDecision {
   readonly [entryName: string]: boolean;
 }
 
-export interface ExtractOptions {
+export interface ImportOptions {
   readonly force: boolean;
   readonly env: NodeJS.ProcessEnv;
 }
@@ -85,4 +85,21 @@ export interface ExtractOptions {
 export interface MergeOutcome {
   readonly merged: McpRegistry;
   readonly conflicts: readonly string[];
+}
+
+export type ExportErrorType = 'ParseFailed' | 'IOError' | 'Unknown';
+
+export interface ExportError {
+  readonly type: ExportErrorType;
+  readonly message: string;
+  readonly cause?: unknown;
+}
+
+export interface ExportOptions {
+  readonly env: NodeJS.ProcessEnv;
+  readonly tools: readonly string[];
+}
+
+export interface ExportSummary {
+  readonly updatedTools: readonly string[];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,13 @@
 export interface McpEntry {
-  readonly command: string;
+  readonly command?: string;
   readonly args?: readonly string[];
   readonly type?: string;
   readonly env?: Readonly<Record<string, string>>;
   readonly transport?: string;
   readonly capabilities?: unknown;
   readonly project_path?: string;
+  readonly url?: string;
+  readonly headers?: Readonly<Record<string, string>>;
 }
 
 export type McpRegistry = Readonly<Record<string, McpEntry>>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,9 +5,14 @@ export interface McpEntry {
   readonly env?: Readonly<Record<string, string>>;
   readonly transport?: string;
   readonly capabilities?: unknown;
+  readonly project_path?: string;
 }
 
 export type McpRegistry = Readonly<Record<string, McpEntry>>;
+
+export interface McpConfig {
+  readonly mcpServers: McpRegistry;
+}
 
 export interface ConfigPaths {
   readonly configFile: string;
@@ -42,4 +47,42 @@ export interface Logger {
 export interface RegistryLoad {
   readonly registry: McpRegistry;
   readonly source: 'existing' | 'initialized';
+}
+
+export type ExtractErrorType = 'SourceMissing' | 'ParseFailed' | 'ValidationFailed' | 'IOError';
+
+export interface ExtractError {
+  readonly type: ExtractErrorType;
+  readonly message: string;
+  readonly cause?: unknown;
+}
+
+export interface SourceData {
+  readonly entries: McpRegistry;
+  readonly promptRequired: readonly string[];
+}
+
+export interface ToolProfile {
+  readonly readSource: () => Promise<Result<SourceData, ExtractError>>;
+  readonly mapToRegistry: (data: unknown) => Result<McpRegistry, ExtractError>;
+}
+
+export interface ExtractionSummary {
+  readonly addedCount: number;
+  readonly skippedEntries: readonly string[];
+  readonly tool: string;
+}
+
+export interface OverwriteDecision {
+  readonly [entryName: string]: boolean;
+}
+
+export interface ExtractOptions {
+  readonly force: boolean;
+  readonly env: NodeJS.ProcessEnv;
+}
+
+export interface MergeOutcome {
+  readonly merged: McpRegistry;
+  readonly conflicts: readonly string[];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,10 +9,6 @@ export interface McpEntry {
 
 export type McpRegistry = Readonly<Record<string, McpEntry>>;
 
-export interface McpConfig {
-  readonly mcpServers: McpRegistry;
-}
-
 export interface ConfigPaths {
   readonly configFile: string;
   readonly backupFile: string;
@@ -29,7 +25,7 @@ export type Result<T, E> =
   | { readonly success: false; readonly error: E };
 
 export interface IOError {
-  readonly type: 'FileNotFound' | 'PermissionDenied' | 'InvalidJSON' | 'Unknown';
+  readonly type: 'FileNotFound' | 'PermissionDenied' | 'InvalidJSON' | 'InvalidFormat' | 'Unknown';
   readonly message: string;
   readonly cause?: unknown;
 }
@@ -41,4 +37,9 @@ export interface Logger {
   readonly info: (message: string) => void;
   readonly warn: (message: string) => void;
   readonly error: (message: string) => void;
+}
+
+export interface RegistryLoad {
+  readonly registry: McpRegistry;
+  readonly source: 'existing' | 'initialized';
 }

--- a/tests/add-command.test.ts
+++ b/tests/add-command.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { buildEntryFromCli } from '../src/services/add-command.js';
+import type { AddCommandInput } from '../src/services/add-command.js';
+
+describe('buildEntryFromCli', () => {
+  it('creates stdio entry with command, args, env, and project path', () => {
+    const input: AddCommandInput = {
+      name: 'local-tool',
+      target: 'node',
+      commandArguments: ['script.js', '--watch'],
+      options: {
+        transport: 'stdio',
+        env: ['API_KEY=secret'],
+        headers: [],
+        projectPath: '/workspace/project'
+      }
+    };
+
+    const result = buildEntryFromCli(input);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual({
+      command: 'node',
+      args: ['script.js', '--watch'],
+      env: { API_KEY: 'secret' },
+      project_path: '/workspace/project'
+    });
+  });
+
+  it('creates sse entry with url and headers', () => {
+    const input: AddCommandInput = {
+      name: 'remote-sse',
+      target: 'https://example.com/sse',
+      commandArguments: [],
+      options: {
+        transport: 'sse',
+        env: [],
+        headers: ['Authorization: Bearer token']
+      }
+    };
+
+    const result = buildEntryFromCli(input);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual({
+      type: 'sse',
+      transport: 'sse',
+      url: 'https://example.com/sse',
+      headers: { Authorization: 'Bearer token' }
+    });
+  });
+
+  it('fails when stdio entry lacks command', () => {
+    const input: AddCommandInput = {
+      name: 'local-tool',
+      target: undefined,
+      commandArguments: [],
+      options: {
+        transport: 'stdio',
+        env: [],
+        headers: []
+      }
+    };
+
+    const result = buildEntryFromCli(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain('command');
+    }
+  });
+
+  it('fails when remote entry lacks url', () => {
+    const input: AddCommandInput = {
+      name: 'remote-sse',
+      target: undefined,
+      commandArguments: [],
+      options: {
+        transport: 'sse',
+        env: [],
+        headers: []
+      }
+    };
+
+    const result = buildEntryFromCli(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain('url');
+    }
+  });
+
+  it('fails when header format is invalid', () => {
+    const input: AddCommandInput = {
+      name: 'remote-sse',
+      target: 'https://example.com',
+      commandArguments: [],
+      options: {
+        transport: 'sse',
+        env: [],
+        headers: ['invalid-header']
+      }
+    };
+
+    const result = buildEntryFromCli(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain('header');
+    }
+  });
+});

--- a/tests/config-service.test.ts
+++ b/tests/config-service.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { resolveConfigPaths, readRegistry, writeRegistry, ensureBackup } from '../src/services/config-service.js';
+import type { McpRegistry } from '../src/types/index.js';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    ...actual,
+    promises: {
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      mkdir: vi.fn(),
+      access: vi.fn(),
+      copyFile: vi.fn()
+    }
+  };
+});
+
+vi.mock('os', () => ({
+  homedir: vi.fn(() => '/home/test')
+}));
+
+const mockFs = fs as any;
+
+describe('resolveConfigPaths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return default paths when MCP_CONFIG_DIR is not set', () => {
+    const env = {};
+    const result = resolveConfigPaths(env);
+
+    expect(result).toEqual({
+      configDir: '/home/test/.manage_mcp',
+      configFile: '/home/test/.manage_mcp/mcp.json',
+      backupFile: '/home/test/.manage_mcp/mcp.json.bak'
+    });
+  });
+
+  it('should return custom paths when MCP_CONFIG_DIR is set', () => {
+    const env = { MCP_CONFIG_DIR: '/custom/path' };
+    const result = resolveConfigPaths(env);
+
+    expect(result).toEqual({
+      configDir: '/custom/path',
+      configFile: '/custom/path/mcp.json',
+      backupFile: '/custom/path/mcp.json.bak'
+    });
+  });
+});
+
+describe('readRegistry', () => {
+  const paths = {
+    configDir: '/test',
+    configFile: '/test/mcp.json',
+    backupFile: '/test/mcp.json.bak'
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return empty registry when file does not exist', async () => {
+    mockFs.readFile.mockRejectedValue({ code: 'ENOENT' });
+
+    const result = await readRegistry(paths);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({});
+    }
+  });
+
+  it('should return parsed registry when file exists', async () => {
+    const registryData = { 'test': { command: 'docker' } };
+    const configData = { mcpServers: registryData };
+    mockFs.readFile.mockResolvedValue(JSON.stringify(configData));
+
+    const result = await readRegistry(paths);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(registryData);
+    }
+  });
+
+  it('should handle legacy format (no mcpServers key)', async () => {
+    const registryData = { 'test': { command: 'docker' } };
+    mockFs.readFile.mockResolvedValue(JSON.stringify(registryData));
+
+    const result = await readRegistry(paths);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({});
+    }
+  });
+
+  it('should return error for invalid JSON', async () => {
+    mockFs.readFile.mockResolvedValue('invalid json');
+
+    const result = await readRegistry(paths);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.type).toBe('InvalidJSON');
+    }
+  });
+
+  it('should return error for permission denied', async () => {
+    mockFs.readFile.mockRejectedValue({ code: 'EACCES' });
+
+    const result = await readRegistry(paths);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.type).toBe('PermissionDenied');
+    }
+  });
+});
+
+describe('writeRegistry', () => {
+  const paths = {
+    configDir: '/test',
+    configFile: '/test/mcp.json',
+    backupFile: '/test/mcp.json.bak'
+  };
+
+  const registry: McpRegistry = {
+    'test': { command: 'docker' }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create directory and write file successfully', async () => {
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.writeFile.mockResolvedValue(undefined);
+
+    const result = await writeRegistry(paths, registry);
+
+    expect(result.success).toBe(true);
+    expect(mockFs.mkdir).toHaveBeenCalledWith('/test', { recursive: true });
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      '/test/mcp.json',
+      JSON.stringify({ mcpServers: registry }, null, 2),
+      'utf8'
+    );
+  });
+
+  it('should return error when write fails', async () => {
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.writeFile.mockRejectedValue(new Error('Write failed'));
+
+    const result = await writeRegistry(paths, registry);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.type).toBe('Unknown');
+      expect(result.error.message).toContain('Write failed');
+    }
+  });
+});
+
+describe('ensureBackup', () => {
+  const paths = {
+    configDir: '/test',
+    configFile: '/test/mcp.json',
+    backupFile: '/test/mcp.json.bak'
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create backup when source file exists', async () => {
+    mockFs.access.mockResolvedValue(undefined);
+    mockFs.copyFile.mockResolvedValue(undefined);
+
+    const result = await ensureBackup(paths);
+
+    expect(result.success).toBe(true);
+    expect(mockFs.copyFile).toHaveBeenCalledWith('/test/mcp.json', '/test/mcp.json.bak');
+  });
+
+  it('should succeed when source file does not exist', async () => {
+    mockFs.access.mockRejectedValue({ code: 'ENOENT' });
+
+    const result = await ensureBackup(paths);
+
+    expect(result.success).toBe(true);
+    expect(mockFs.copyFile).not.toHaveBeenCalled();
+  });
+
+  it('should return error when backup fails', async () => {
+    mockFs.access.mockResolvedValue(undefined);
+    mockFs.copyFile.mockRejectedValue(new Error('Backup failed'));
+
+    const result = await ensureBackup(paths);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.type).toBe('Unknown');
+    }
+  });
+
+  it('should return error for permission denied during access check', async () => {
+    mockFs.access.mockRejectedValue({ code: 'EACCES' });
+
+    const result = await ensureBackup(paths);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.type).toBe('Unknown');
+    }
+  });
+});

--- a/tests/config-service.test.ts
+++ b/tests/config-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { promises as fs } from 'fs';
 import { resolveConfigPaths, readRegistry, writeRegistry, ensureBackup } from '../src/services/config-service.js';
 import type { McpRegistry } from '../src/types/index.js';
@@ -21,7 +21,13 @@ vi.mock('os', () => ({
   homedir: vi.fn(() => '/home/test')
 }));
 
-const mockFs = fs as any;
+const mockFs = fs as unknown as {
+  readFile: ReturnType<typeof vi.fn>;
+  writeFile: ReturnType<typeof vi.fn>;
+  mkdir: ReturnType<typeof vi.fn>;
+  access: ReturnType<typeof vi.fn>;
+  copyFile: ReturnType<typeof vi.fn>;
+};
 
 describe('resolveConfigPaths', () => {
   beforeEach(() => {

--- a/tests/export-service.test.ts
+++ b/tests/export-service.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { exportMcpConfig, resolveExporter } from '../src/services/export-service.js';
+import type { ExportOptions, McpRegistry, ConfigPaths, RegistryLoad } from '../src/types/index.js';
+
+const mockConfigService = vi.hoisted(() => ({
+  resolveConfigPaths: vi.fn(),
+  readRegistry: vi.fn()
+}));
+
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+}));
+
+vi.mock('../src/services/config-service.js', () => mockConfigService);
+vi.mock('../src/infra/logger.js', () => ({
+  createLogger: vi.fn(() => mockLogger)
+}));
+
+const mockExporter = vi.hoisted(() => ({
+  write: vi.fn()
+}));
+
+vi.mock('../src/services/target-writers/claude-code-writer.js', () => ({
+  createClaudeCodeExporter: vi.fn(() => mockExporter)
+}));
+vi.mock('../src/services/target-writers/claude-desktop-writer.js', () => ({
+  createClaudeDesktopExporter: vi.fn(() => mockExporter)
+}));
+vi.mock('../src/services/target-writers/cursor-writer.js', () => ({
+  createCursorExporter: vi.fn(() => mockExporter)
+}));
+vi.mock('../src/services/target-writers/codex-writer.js', () => ({
+  createCodexExporter: vi.fn(() => mockExporter)
+}));
+
+describe('export-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('resolveExporter', () => {
+    it('returns exporter for supported tool', () => {
+      const result = resolveExporter('ClaudeCode');
+      expect(result.success).toBe(true);
+    });
+
+    it('returns error for unsupported tool', () => {
+      const result = resolveExporter('Unknown');
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('exportMcpConfig', () => {
+    const options: ExportOptions = { env: {}, tools: ['ClaudeCode', 'Cursor'] };
+    const mockPaths: ConfigPaths = {
+      configDir: '/config',
+      configFile: '/config/mcp.json',
+      backupFile: '/config/mcp.json.bak'
+    };
+    const registry: McpRegistry = {
+      global: { command: 'npx', args: ['tool'] }
+    };
+
+    it('writes registry to requested exporters', async () => {
+      const registryLoad: RegistryLoad = { registry, source: 'existing' };
+      mockConfigService.resolveConfigPaths.mockReturnValue(mockPaths);
+      mockConfigService.readRegistry.mockResolvedValue({ success: true, data: registryLoad });
+      mockExporter.write.mockResolvedValue({ success: true, data: undefined });
+
+      const summary = await exportMcpConfig(options.tools, options);
+
+      expect(mockExporter.write).toHaveBeenCalledTimes(options.tools.length);
+      expect(summary.updatedTools).toEqual(options.tools);
+    });
+
+    it('throws when registry cannot be read', async () => {
+      mockConfigService.resolveConfigPaths.mockReturnValue(mockPaths);
+      mockConfigService.readRegistry.mockResolvedValue({
+        success: false,
+        error: {
+          type: 'InvalidJSON',
+          message: 'bad json'
+        }
+      });
+
+      await expect(exportMcpConfig(options.tools, options)).rejects.toThrow('bad json');
+    });
+
+    it('throws when exporter fails', async () => {
+      const registryLoad: RegistryLoad = { registry, source: 'existing' };
+      mockConfigService.resolveConfigPaths.mockReturnValue(mockPaths);
+      mockConfigService.readRegistry.mockResolvedValue({ success: true, data: registryLoad });
+      mockExporter.write.mockResolvedValueOnce({
+        success: false,
+        error: {
+          type: 'IOError',
+          message: 'failed to write'
+        }
+      });
+
+      await expect(exportMcpConfig(['ClaudeCode'], options)).rejects.toThrow('failed to write');
+    });
+  });
+});

--- a/tests/extract-service.test.ts
+++ b/tests/extract-service.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { extractMcpConfig, resolveProfile, promptOverwrite, mergeEntries } from '../src/services/extract-service.js';
+import type { ExtractOptions, McpRegistry, ConfigPaths, RegistryLoad } from '../src/types/index.js';
+
+const mockConfigService = vi.hoisted(() => ({
+  resolveConfigPaths: vi.fn(),
+  readRegistry: vi.fn(),
+  writeRegistry: vi.fn(),
+  ensureBackup: vi.fn()
+}));
+
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn()
+}));
+
+vi.mock('../src/services/config-service.js', () => mockConfigService);
+vi.mock('../src/infra/logger.js', () => ({
+  createLogger: vi.fn(() => mockLogger)
+}));
+
+const mockClaudeCodeProfile = vi.hoisted(() => ({
+  readSource: vi.fn(),
+  mapToRegistry: vi.fn()
+}));
+
+vi.mock('../src/services/source-readers/claude-code.js', () => ({
+  createClaudeCodeProfile: vi.fn(() => mockClaudeCodeProfile)
+}));
+vi.mock('../src/services/source-readers/claude-desktop.js', () => ({
+  createClaudeDesktopProfile: vi.fn(() => mockClaudeCodeProfile)
+}));
+vi.mock('../src/services/source-readers/cursor.js', () => ({
+  createCursorProfile: vi.fn(() => mockClaudeCodeProfile)
+}));
+vi.mock('../src/services/source-readers/codex.js', () => ({
+  createCodexProfile: vi.fn(() => mockClaudeCodeProfile)
+}));
+
+describe('extract-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('resolveProfile', () => {
+    it('should return ClaudeCode profile for "ClaudeCode" tool', () => {
+      const result = resolveProfile('ClaudeCode');
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBeDefined();
+        expect(typeof result.data.readSource).toBe('function');
+        expect(typeof result.data.mapToRegistry).toBe('function');
+      }
+    });
+
+    it('should return error for unsupported tool', () => {
+      const result = resolveProfile('UnsupportedTool');
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('ValidationFailed');
+        expect(result.error.message).toContain('Unsupported tool');
+      }
+    });
+  });
+
+  describe('promptOverwrite', () => {
+    it('should return all true when force is enabled', async () => {
+      const mockPrompt = vi.fn();
+      const names = ['entry1', 'entry2'];
+
+      const result = await promptOverwrite(names, true, mockPrompt);
+
+      expect(result).toEqual({ entry1: true, entry2: true });
+      expect(mockPrompt).not.toHaveBeenCalled();
+    });
+
+    it('should use prompt function when force is disabled', async () => {
+      const mockPrompt = vi.fn().mockResolvedValue({ entry1: true, entry2: false });
+      const names = ['entry1', 'entry2'];
+
+      const result = await promptOverwrite(names, false, mockPrompt);
+
+      expect(result).toEqual({ entry1: true, entry2: false });
+      expect(mockPrompt).toHaveBeenCalledWith(names);
+    });
+  });
+
+  describe('mergeEntries', () => {
+    it('should merge entries with no conflicts', () => {
+      const base: McpRegistry = { 'existing': { command: 'test' } };
+      const additions: McpRegistry = { 'new': { command: 'new-test' } };
+      const decisions = {};
+
+      const result = mergeEntries(base, additions, decisions);
+
+      expect(result.conflicts).toEqual([]);
+      expect(result.merged).toEqual({
+        'existing': { command: 'test' },
+        'new': { command: 'new-test' }
+      });
+    });
+
+    it('should detect conflicts and apply decisions', () => {
+      const base: McpRegistry = { 'conflict': { command: 'old' } };
+      const additions: McpRegistry = { 'conflict': { command: 'new' } };
+      const decisions = { 'conflict': true };
+
+      const result = mergeEntries(base, additions, decisions);
+
+      expect(result.conflicts).toEqual(['conflict']);
+      expect(result.merged).toEqual({ 'conflict': { command: 'new' } });
+    });
+  });
+
+  describe('extractMcpConfig', () => {
+    it('should extract and merge MCP config successfully', async () => {
+      const tool = 'ClaudeCode';
+      const options: ExtractOptions = { force: false, env: {} };
+      const mockPaths: ConfigPaths = {
+        configDir: '/test',
+        configFile: '/test/mcp.json',
+        backupFile: '/test/mcp.json.bak'
+      };
+      const mockRegistry: RegistryLoad = {
+        registry: {},
+        source: 'initialized'
+      };
+
+      mockConfigService.resolveConfigPaths.mockReturnValue(mockPaths);
+      mockConfigService.readRegistry.mockResolvedValue({ success: true, data: mockRegistry });
+      mockConfigService.ensureBackup.mockResolvedValue({ success: true, data: undefined });
+      mockConfigService.writeRegistry.mockResolvedValue({ success: true, data: undefined });
+
+      mockClaudeCodeProfile.readSource.mockResolvedValue({
+        success: true,
+        data: {
+          entries: {},
+          promptRequired: []
+        }
+      });
+
+      const result = await extractMcpConfig(tool, options);
+
+      expect(result.tool).toBe(tool);
+      expect(result.addedCount).toBe(0);
+      expect(mockLogger.info).toHaveBeenCalled();
+    });
+
+    it('should handle source missing case', async () => {
+      const tool = 'ClaudeCode';
+      const options: ExtractOptions = { force: false, env: {} };
+
+      mockClaudeCodeProfile.readSource.mockResolvedValue({
+        success: false,
+        error: {
+          type: 'SourceMissing',
+          message: 'File not found'
+        }
+      });
+
+      const result = await extractMcpConfig(tool, options);
+
+      expect(result.tool).toBe(tool);
+      expect(result.addedCount).toBe(0);
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('No MCP entries found'));
+    });
+  });
+});

--- a/tests/import-service.test.ts
+++ b/tests/import-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { extractMcpConfig, resolveProfile, promptOverwrite, mergeEntries } from '../src/services/extract-service.js';
-import type { ExtractOptions, McpRegistry, ConfigPaths, RegistryLoad } from '../src/types/index.js';
+import { importMcpConfig, resolveProfile, promptOverwrite, mergeEntries } from '../src/services/import-service.js';
+import type { ImportOptions, McpRegistry, ConfigPaths, RegistryLoad } from '../src/types/index.js';
 
 const mockConfigService = vi.hoisted(() => ({
   resolveConfigPaths: vi.fn(),
@@ -39,7 +39,7 @@ vi.mock('../src/services/source-readers/codex.js', () => ({
   createCodexProfile: vi.fn(() => mockClaudeCodeProfile)
 }));
 
-describe('extract-service', () => {
+describe('import-service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -116,10 +116,10 @@ describe('extract-service', () => {
     });
   });
 
-  describe('extractMcpConfig', () => {
-    it('should extract and merge MCP config successfully', async () => {
+  describe('importMcpConfig', () => {
+    it('should import and merge MCP config successfully', async () => {
       const tool = 'ClaudeCode';
-      const options: ExtractOptions = { force: false, env: {} };
+      const options: ImportOptions = { force: false, env: {} };
       const mockPaths: ConfigPaths = {
         configDir: '/test',
         configFile: '/test/mcp.json',
@@ -143,7 +143,7 @@ describe('extract-service', () => {
         }
       });
 
-      const result = await extractMcpConfig(tool, options);
+      const result = await importMcpConfig(tool, options);
 
       expect(result.tool).toBe(tool);
       expect(result.addedCount).toBe(0);
@@ -152,7 +152,7 @@ describe('extract-service', () => {
 
     it('should handle source missing case', async () => {
       const tool = 'ClaudeCode';
-      const options: ExtractOptions = { force: false, env: {} };
+      const options: ImportOptions = { force: false, env: {} };
 
       mockClaudeCodeProfile.readSource.mockResolvedValue({
         success: false,
@@ -162,7 +162,7 @@ describe('extract-service', () => {
         }
       });
 
-      const result = await extractMcpConfig(tool, options);
+      const result = await importMcpConfig(tool, options);
 
       expect(result.tool).toBe(tool);
       expect(result.addedCount).toBe(0);

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createLogger } from '../src/infra/logger.js';
+
+// Mock console
+const mockConsole = {
+  log: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+};
+
+vi.stubGlobal('console', mockConsole);
+
+describe('createLogger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('with verbose=false', () => {
+    const logger = createLogger(false);
+
+    it('should not log debug messages', () => {
+      logger.debug('test debug message');
+      expect(mockConsole.log).not.toHaveBeenCalled();
+    });
+
+    it('should log info messages', () => {
+      logger.info('test info message');
+      expect(mockConsole.log).toHaveBeenCalledWith('[INFO] test info message');
+    });
+
+    it('should log warn messages', () => {
+      logger.warn('test warn message');
+      expect(mockConsole.warn).toHaveBeenCalledWith('[WARN] test warn message');
+    });
+
+    it('should log error messages', () => {
+      logger.error('test error message');
+      expect(mockConsole.error).toHaveBeenCalledWith('[ERROR] test error message');
+    });
+  });
+
+  describe('with verbose=true', () => {
+    const logger = createLogger(true);
+
+    it('should log debug messages', () => {
+      logger.debug('test debug message');
+      expect(mockConsole.log).toHaveBeenCalledWith('[DEBUG] test debug message');
+    });
+
+    it('should log info messages', () => {
+      logger.info('test info message');
+      expect(mockConsole.log).toHaveBeenCalledWith('[INFO] test info message');
+    });
+
+    it('should log warn messages', () => {
+      logger.warn('test warn message');
+      expect(mockConsole.warn).toHaveBeenCalledWith('[WARN] test warn message');
+    });
+
+    it('should log error messages', () => {
+      logger.error('test error message');
+      expect(mockConsole.error).toHaveBeenCalledWith('[ERROR] test error message');
+    });
+  });
+
+  describe('message formatting', () => {
+    const logger = createLogger(true);
+
+    it('should handle empty messages', () => {
+      logger.info('');
+      expect(mockConsole.log).toHaveBeenCalledWith('[INFO] ');
+    });
+
+    it('should handle multiline messages', () => {
+      logger.info('line1\nline2');
+      expect(mockConsole.log).toHaveBeenCalledWith('[INFO] line1\nline2');
+    });
+
+    it('should handle messages with special characters', () => {
+      logger.info('message with "quotes" and símb©ls');
+      expect(mockConsole.log).toHaveBeenCalledWith('[INFO] message with "quotes" and símb©ls');
+    });
+  });
+});

--- a/tests/mcp-service.test.ts
+++ b/tests/mcp-service.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { sortEntries, addEntry, removeEntry } from '../src/services/mcp-service.js';
+import type { McpRegistry } from '../src/types/index.js';
+
+describe('sortEntries', () => {
+  it('should return empty array for empty registry', () => {
+    const registry: McpRegistry = {};
+    const result = sortEntries(registry);
+    expect(result).toEqual([]);
+  });
+
+  it('should return entries sorted by name', () => {
+    const registry: McpRegistry = {
+      'zebra': { command: 'z' },
+      'alpha': { command: 'a' },
+      'beta': { command: 'b' }
+    };
+    const result = sortEntries(registry);
+    expect(result).toEqual([
+      { name: 'alpha', entry: { command: 'a' } },
+      { name: 'beta', entry: { command: 'b' } },
+      { name: 'zebra', entry: { command: 'z' } }
+    ]);
+  });
+
+  it('should handle complex entries with all fields', () => {
+    const registry: McpRegistry = {
+      'complex': {
+        command: 'docker',
+        args: ['run', '-i'],
+        type: 'stdio',
+        env: { 'API_KEY': 'test' }
+      },
+      'simple': { command: 'npx' }
+    };
+    const result = sortEntries(registry);
+    expect(result).toEqual([
+      {
+        name: 'complex',
+        entry: {
+          command: 'docker',
+          args: ['run', '-i'],
+          type: 'stdio',
+          env: { 'API_KEY': 'test' }
+        }
+      },
+      { name: 'simple', entry: { command: 'npx' } }
+    ]);
+  });
+});
+
+describe('addEntry', () => {
+  it('should add entry to empty registry', () => {
+    const registry: McpRegistry = {};
+    const entry = { command: 'docker' };
+    const result = addEntry(registry, 'test', entry);
+
+    expect(result).toEqual({
+      'test': { command: 'docker' }
+    });
+    expect(registry).toEqual({}); // Original should be unchanged
+  });
+
+  it('should add entry to existing registry', () => {
+    const registry: McpRegistry = {
+      'existing': { command: 'npx' }
+    };
+    const entry = { command: 'docker' };
+    const result = addEntry(registry, 'new', entry);
+
+    expect(result).toEqual({
+      'existing': { command: 'npx' },
+      'new': { command: 'docker' }
+    });
+    expect(registry).toEqual({
+      'existing': { command: 'npx' }
+    }); // Original should be unchanged
+  });
+
+  it('should overwrite existing entry with same name', () => {
+    const registry: McpRegistry = {
+      'test': { command: 'old' }
+    };
+    const entry = { command: 'new' };
+    const result = addEntry(registry, 'test', entry);
+
+    expect(result).toEqual({
+      'test': { command: 'new' }
+    });
+  });
+
+  it('should handle complex entries', () => {
+    const registry: McpRegistry = {};
+    const entry = {
+      command: 'docker',
+      args: ['run', '-i', '--rm'],
+      type: 'stdio',
+      env: { 'API_KEY': 'test123' }
+    };
+    const result = addEntry(registry, 'complex', entry);
+
+    expect(result).toEqual({
+      'complex': entry
+    });
+  });
+});
+
+describe('removeEntry', () => {
+  it('should remove existing entry', () => {
+    const registry: McpRegistry = {
+      'keep': { command: 'keep' },
+      'remove': { command: 'remove' }
+    };
+    const result = removeEntry(registry, 'remove');
+
+    expect(result).toEqual({
+      'keep': { command: 'keep' }
+    });
+    expect(registry).toEqual({
+      'keep': { command: 'keep' },
+      'remove': { command: 'remove' }
+    }); // Original should be unchanged
+  });
+
+  it('should return unchanged registry when entry does not exist', () => {
+    const registry: McpRegistry = {
+      'existing': { command: 'test' }
+    };
+    const result = removeEntry(registry, 'nonexistent');
+
+    expect(result).toEqual({
+      'existing': { command: 'test' }
+    });
+    expect(registry).toEqual({
+      'existing': { command: 'test' }
+    }); // Original should be unchanged
+  });
+
+  it('should return empty registry when removing last entry', () => {
+    const registry: McpRegistry = {
+      'only': { command: 'test' }
+    };
+    const result = removeEntry(registry, 'only');
+
+    expect(result).toEqual({});
+  });
+
+  it('should handle empty registry', () => {
+    const registry: McpRegistry = {};
+    const result = removeEntry(registry, 'nonexistent');
+
+    expect(result).toEqual({});
+  });
+});

--- a/tests/source-readers/claude-code.test.ts
+++ b/tests/source-readers/claude-code.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createClaudeCodeProfile } from '../../src/services/source-readers/claude-code.js';
-import type { McpRegistry } from '../../src/types/index.js';
 
 const mockFs = vi.hoisted(() => ({
   readFile: vi.fn()
@@ -23,7 +22,7 @@ describe('claude-code profile', () => {
   });
 
   describe('mapToRegistry', () => {
-    it('should extract MCP entries from top-level mcpServers', () => {
+    it('should import MCP entries from top-level mcpServers', () => {
       const profile = createClaudeCodeProfile();
       const sourceData = {
         mcpServers: {
@@ -47,7 +46,7 @@ describe('claude-code profile', () => {
       }
     });
 
-    it('should extract MCP entries from project mcpServers with prefixed names', () => {
+    it('should import MCP entries from project mcpServers with prefixed names', () => {
       const profile = createClaudeCodeProfile();
       const sourceData = {
         projects: {

--- a/tests/source-readers/claude-code.test.ts
+++ b/tests/source-readers/claude-code.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createClaudeCodeProfile } from '../../src/services/source-readers/claude-code.js';
+import type { McpRegistry } from '../../src/types/index.js';
+
+const mockFs = vi.hoisted(() => ({
+  readFile: vi.fn()
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    ...actual,
+    promises: mockFs
+  };
+});
+
+const mockHomedir = vi.hoisted(() => vi.fn(() => '/home/test'));
+vi.mock('os', () => ({ homedir: mockHomedir }));
+
+describe('claude-code profile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('mapToRegistry', () => {
+    it('should extract MCP entries from top-level mcpServers', () => {
+      const profile = createClaudeCodeProfile();
+      const sourceData = {
+        mcpServers: {
+          'test-server': {
+            command: 'node',
+            args: ['server.js']
+          }
+        }
+      };
+
+      const result = profile.mapToRegistry(sourceData);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({
+          'test-server': {
+            command: 'node',
+            args: ['server.js']
+          }
+        });
+      }
+    });
+
+    it('should extract MCP entries from project mcpServers with prefixed names', () => {
+      const profile = createClaudeCodeProfile();
+      const sourceData = {
+        projects: {
+          '/path/to/project': {
+            mcpServers: {
+              'project-server': {
+                command: 'docker',
+                args: ['run', 'image']
+              }
+            }
+          }
+        }
+      };
+
+      const result = profile.mapToRegistry(sourceData);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({
+          'project[project].project-server': {
+            command: 'docker',
+            args: ['run', 'image'],
+            project_path: '/path/to/project'
+          }
+        });
+      }
+    });
+
+    it('should return empty registry for invalid data', () => {
+      const profile = createClaudeCodeProfile();
+      const result = profile.mapToRegistry(null);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({});
+      }
+    });
+  });
+
+  describe('readSource', () => {
+    it('should read and parse ~/.claude.json successfully', async () => {
+      const profile = createClaudeCodeProfile();
+      const mockData = {
+        mcpServers: {
+          'test': { command: 'test' }
+        }
+      };
+      mockFs.readFile.mockResolvedValue(JSON.stringify(mockData));
+
+      const result = await profile.readSource();
+
+      expect(result.success).toBe(true);
+      expect(mockFs.readFile).toHaveBeenCalledWith('/home/test/.claude.json', 'utf8');
+    });
+
+    it('should return SourceMissing error when file does not exist', async () => {
+      const profile = createClaudeCodeProfile();
+      mockFs.readFile.mockRejectedValue({ code: 'ENOENT' });
+
+      const result = await profile.readSource();
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('SourceMissing');
+      }
+    });
+
+    it('should return ParseFailed error for invalid JSON', async () => {
+      const profile = createClaudeCodeProfile();
+      mockFs.readFile.mockResolvedValue('invalid json');
+
+      const result = await profile.readSource();
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('ParseFailed');
+      }
+    });
+  });
+});

--- a/tests/source-readers/claude-desktop.test.ts
+++ b/tests/source-readers/claude-desktop.test.ts
@@ -22,7 +22,7 @@ describe('claude-desktop profile', () => {
   });
 
   describe('mapToRegistry', () => {
-    it('should extract MCP entries from mcpServers', () => {
+    it('should import MCP entries from mcpServers', () => {
       const profile = createClaudeDesktopProfile();
       const sourceData = {
         mcpServers: {

--- a/tests/source-readers/claude-desktop.test.ts
+++ b/tests/source-readers/claude-desktop.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createClaudeDesktopProfile } from '../../src/services/source-readers/claude-desktop.js';
+
+const mockFs = vi.hoisted(() => ({
+  readFile: vi.fn()
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    ...actual,
+    promises: mockFs
+  };
+});
+
+const mockHomedir = vi.hoisted(() => vi.fn(() => '/home/test'));
+vi.mock('os', () => ({ homedir: mockHomedir }));
+
+describe('claude-desktop profile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('mapToRegistry', () => {
+    it('should extract MCP entries from mcpServers', () => {
+      const profile = createClaudeDesktopProfile();
+      const sourceData = {
+        mcpServers: {
+          'context7': {
+            command: 'npx',
+            args: ['@context7/mcp']
+          },
+          'gitlab': {
+            command: 'docker',
+            args: ['run', 'gitlab-mcp']
+          }
+        }
+      };
+
+      const result = profile.mapToRegistry(sourceData);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({
+          'context7': {
+            command: 'npx',
+            args: ['@context7/mcp']
+          },
+          'gitlab': {
+            command: 'docker',
+            args: ['run', 'gitlab-mcp']
+          }
+        });
+      }
+    });
+
+    it('should return empty registry for invalid data', () => {
+      const profile = createClaudeDesktopProfile();
+      const result = profile.mapToRegistry({ invalid: 'data' });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({});
+      }
+    });
+  });
+
+  describe('readSource', () => {
+    it('should read claude_desktop_config.json successfully', async () => {
+      const profile = createClaudeDesktopProfile();
+      const mockData = {
+        mcpServers: {
+          'test': { command: 'test' }
+        }
+      };
+      mockFs.readFile.mockResolvedValue(JSON.stringify(mockData));
+
+      const result = await profile.readSource();
+
+      expect(result.success).toBe(true);
+      expect(mockFs.readFile).toHaveBeenCalledWith('/home/test/Library/Application Support/Claude/claude_desktop_config.json', 'utf8');
+    });
+
+    it('should return SourceMissing error when file does not exist', async () => {
+      const profile = createClaudeDesktopProfile();
+      mockFs.readFile.mockRejectedValue({ code: 'ENOENT' });
+
+      const result = await profile.readSource();
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('SourceMissing');
+      }
+    });
+  });
+});

--- a/tests/source-readers/codex.test.ts
+++ b/tests/source-readers/codex.test.ts
@@ -28,7 +28,7 @@ describe('codex profile', () => {
   });
 
   describe('mapToRegistry', () => {
-    it('should extract MCP entries from mcp_servers sections', () => {
+    it('should import MCP entries from mcp_servers sections', () => {
       const profile = createCodexProfile();
       const sourceData = {
         mcp_servers: {

--- a/tests/source-readers/codex.test.ts
+++ b/tests/source-readers/codex.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCodexProfile } from '../../src/services/source-readers/codex.js';
+
+const mockFs = vi.hoisted(() => ({
+  readFile: vi.fn()
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    ...actual,
+    promises: mockFs
+  };
+});
+
+const mockHomedir = vi.hoisted(() => vi.fn(() => '/home/test'));
+vi.mock('os', () => ({ homedir: mockHomedir }));
+
+const mockToml = vi.hoisted(() => ({
+  parse: vi.fn()
+}));
+
+vi.mock('@iarna/toml', () => mockToml);
+
+describe('codex profile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('mapToRegistry', () => {
+    it('should extract MCP entries from mcp_servers sections', () => {
+      const profile = createCodexProfile();
+      const sourceData = {
+        mcp_servers: {
+          context7: {
+            command: 'npx',
+            args: ['@context7/mcp']
+          },
+          gitlab: {
+            command: 'docker',
+            args: ['run', 'gitlab-mcp']
+          }
+        }
+      };
+
+      const result = profile.mapToRegistry(sourceData);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({
+          'context7': {
+            command: 'npx',
+            args: ['@context7/mcp']
+          },
+          'gitlab': {
+            command: 'docker',
+            args: ['run', 'gitlab-mcp']
+          }
+        });
+      }
+    });
+
+    it('should return empty registry when no mcp_servers section', () => {
+      const profile = createCodexProfile();
+      const sourceData = {
+        other_section: {
+          value: 'test'
+        }
+      };
+
+      const result = profile.mapToRegistry(sourceData);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({});
+      }
+    });
+  });
+
+  describe('readSource', () => {
+    it('should read and parse ~/.codex/config.toml successfully', async () => {
+      const profile = createCodexProfile();
+      const tomlContent = `
+[mcp_servers.context7]
+command = "npx"
+args = ["@context7/mcp"]
+`;
+      const parsedData = {
+        mcp_servers: {
+          context7: {
+            command: 'npx',
+            args: ['@context7/mcp']
+          }
+        }
+      };
+
+      mockFs.readFile.mockResolvedValue(tomlContent);
+      mockToml.parse.mockReturnValue(parsedData);
+
+      const result = await profile.readSource();
+
+      expect(result.success).toBe(true);
+      expect(mockFs.readFile).toHaveBeenCalledWith('/home/test/.codex/config.toml', 'utf8');
+      expect(mockToml.parse).toHaveBeenCalledWith(tomlContent);
+    });
+
+    it('should return SourceMissing error when file does not exist', async () => {
+      const profile = createCodexProfile();
+      mockFs.readFile.mockRejectedValue({ code: 'ENOENT' });
+
+      const result = await profile.readSource();
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('SourceMissing');
+      }
+    });
+
+    it('should return ParseFailed error for invalid TOML', async () => {
+      const profile = createCodexProfile();
+      mockFs.readFile.mockResolvedValue('invalid toml [[[');
+      mockToml.parse.mockImplementation(() => {
+        throw new Error('Invalid TOML syntax');
+      });
+
+      const result = await profile.readSource();
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('ParseFailed');
+      }
+    });
+  });
+});

--- a/tests/source-readers/cursor.test.ts
+++ b/tests/source-readers/cursor.test.ts
@@ -22,7 +22,7 @@ describe('cursor profile', () => {
   });
 
   describe('mapToRegistry', () => {
-    it('should extract MCP entries from mcpServers', () => {
+    it('should import MCP entries from mcpServers', () => {
       const profile = createCursorProfile();
       const sourceData = {
         mcpServers: {

--- a/tests/source-readers/cursor.test.ts
+++ b/tests/source-readers/cursor.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCursorProfile } from '../../src/services/source-readers/cursor.js';
+
+const mockFs = vi.hoisted(() => ({
+  readFile: vi.fn()
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    ...actual,
+    promises: mockFs
+  };
+});
+
+const mockHomedir = vi.hoisted(() => vi.fn(() => '/home/test'));
+vi.mock('os', () => ({ homedir: mockHomedir }));
+
+describe('cursor profile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('mapToRegistry', () => {
+    it('should extract MCP entries from mcpServers', () => {
+      const profile = createCursorProfile();
+      const sourceData = {
+        mcpServers: {
+          'playwright': {
+            command: 'npx',
+            args: ['@playwright/mcp']
+          }
+        }
+      };
+
+      const result = profile.mapToRegistry(sourceData);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({
+          'playwright': {
+            command: 'npx',
+            args: ['@playwright/mcp']
+          }
+        });
+      }
+    });
+  });
+
+  describe('readSource', () => {
+    it('should read ~/.cursor/mcp.json successfully', async () => {
+      const profile = createCursorProfile();
+      const mockData = {
+        mcpServers: {
+          'test': { command: 'test' }
+        }
+      };
+      mockFs.readFile.mockResolvedValue(JSON.stringify(mockData));
+
+      const result = await profile.readSource();
+
+      expect(result.success).toBe(true);
+      expect(mockFs.readFile).toHaveBeenCalledWith('/home/test/.cursor/mcp.json', 'utf8');
+    });
+  });
+});

--- a/tests/target-writers/claude-code-writer.test.ts
+++ b/tests/target-writers/claude-code-writer.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createClaudeCodeExporter } from '../../src/services/target-writers/claude-code-writer.js';
+import type { McpRegistry } from '../../src/types/index.js';
+
+const mockFs = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn()
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readFile: mockFs.readFile,
+      writeFile: mockFs.writeFile
+    }
+  };
+});
+
+const mockHomedir = vi.hoisted(() => vi.fn(() => '/home/test'));
+vi.mock('os', () => ({ homedir: mockHomedir }));
+
+const existingConfig = {
+  projects: {
+    '/workspace/old': {
+      mcpServers: {
+        legacy: { command: 'node legacy.js' }
+      }
+    }
+  },
+  mcpServers: {
+    old: { command: 'node old.js' }
+  }
+};
+
+const registry: McpRegistry = {
+  global: { command: 'npx', args: ['tool'] },
+  'project[workspace].alpha': {
+    command: 'docker',
+    args: ['run'],
+    project_path: '/workspace'
+  },
+  'project[workspace].beta': {
+    command: 'docker',
+    args: ['start'],
+    project_path: '/workspace'
+  }
+};
+
+describe('createClaudeCodeExporter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes global and project MCP entries into claude config', async () => {
+    mockFs.readFile.mockResolvedValue(JSON.stringify(existingConfig));
+    mockFs.writeFile.mockResolvedValue(undefined);
+
+    const exporter = createClaudeCodeExporter();
+    const result = await exporter.write(registry);
+
+    expect(result.success).toBe(true);
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      '/home/test/.claude.json',
+      expect.stringContaining('"global"'),
+      'utf8'
+    );
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0][1]);
+    expect(written.mcpServers).toEqual({
+      global: { command: 'npx', args: ['tool'] }
+    });
+    expect(written.projects['/workspace'].mcpServers).toEqual({
+      alpha: { command: 'docker', args: ['run'] },
+      beta: { command: 'docker', args: ['start'] }
+    });
+    expect(written.projects['/workspace'].project_path).toBeUndefined();
+  });
+});

--- a/tests/target-writers/claude-desktop-writer.test.ts
+++ b/tests/target-writers/claude-desktop-writer.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createClaudeDesktopExporter } from '../../src/services/target-writers/claude-desktop-writer.js';
+import type { McpRegistry } from '../../src/types/index.js';
+
+const mockFs = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn()
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readFile: mockFs.readFile,
+      writeFile: mockFs.writeFile
+    }
+  };
+});
+
+const mockHomedir = vi.hoisted(() => vi.fn(() => '/home/test'));
+vi.mock('os', () => ({ homedir: mockHomedir }));
+
+const registry: McpRegistry = {
+  global: { command: 'npx', args: ['tool'] },
+  'project[workspace].alpha': {
+    command: 'docker',
+    args: ['run'],
+    project_path: '/workspace'
+  }
+};
+
+describe('createClaudeDesktopReflector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes only global entries to claude desktop config', async () => {
+    const existing = { mcpServers: { old: { command: 'node old.js' } } };
+    mockFs.readFile.mockResolvedValue(JSON.stringify(existing));
+    mockFs.writeFile.mockResolvedValue(undefined);
+
+    const exporter = createClaudeDesktopExporter();
+    const result = await exporter.write(registry);
+
+    expect(result.success).toBe(true);
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      '/home/test/Library/Application Support/Claude/claude_desktop_config.json',
+      expect.stringContaining('"global"'),
+      'utf8'
+    );
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0][1]);
+    expect(written.mcpServers).toEqual({
+      global: { command: 'npx', args: ['tool'] }
+    });
+  });
+});

--- a/tests/target-writers/codex-writer.test.ts
+++ b/tests/target-writers/codex-writer.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCodexExporter } from '../../src/services/target-writers/codex-writer.js';
+import type { McpRegistry } from '../../src/types/index.js';
+
+const mockFs = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn()
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readFile: mockFs.readFile,
+      writeFile: mockFs.writeFile
+    }
+  };
+});
+
+const mockHomedir = vi.hoisted(() => vi.fn(() => '/home/test'));
+vi.mock('os', () => ({ homedir: mockHomedir }));
+
+const mockToml = vi.hoisted(() => ({
+  stringify: vi.fn((data: unknown) => `stringified:${JSON.stringify(data)}`),
+  parse: vi.fn()
+}));
+
+vi.mock('@iarna/toml', () => mockToml);
+
+const registry: McpRegistry = {
+  global: { command: 'npx', args: ['tool'] },
+  'project[workspace].alpha': {
+    command: 'docker',
+    args: ['run'],
+    project_path: '/workspace'
+  }
+};
+
+describe('createCodexReflector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes only global entries into codex TOML', async () => {
+    mockFs.readFile.mockResolvedValue('existing');
+    mockToml.parse.mockReturnValue({ tools: { web_search: true } });
+    mockFs.writeFile.mockResolvedValue(undefined);
+
+    const exporter = createCodexExporter();
+    const result = await exporter.write(registry);
+
+    expect(result.success).toBe(true);
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      '/home/test/.codex/config.toml',
+      expect.stringContaining('stringified'),
+      'utf8'
+    );
+
+    const writtenObj = mockToml.stringify.mock.calls[0][0];
+    expect(writtenObj.mcp_servers).toEqual({
+      global: {
+        command: 'npx',
+        args: ['tool']
+      }
+    });
+  });
+});

--- a/tests/target-writers/cursor-writer.test.ts
+++ b/tests/target-writers/cursor-writer.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCursorExporter } from '../../src/services/target-writers/cursor-writer.js';
+import type { McpRegistry } from '../../src/types/index.js';
+
+const mockFs = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn()
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readFile: mockFs.readFile,
+      writeFile: mockFs.writeFile
+    }
+  };
+});
+
+const mockHomedir = vi.hoisted(() => vi.fn(() => '/home/test'));
+vi.mock('os', () => ({ homedir: mockHomedir }));
+
+const registry: McpRegistry = {
+  global: { command: 'npx', args: ['tool'] },
+  'project[workspace].alpha': {
+    command: 'docker',
+    args: ['run'],
+    project_path: '/workspace'
+  }
+};
+
+describe('createCursorReflector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes only global entries to cursor config', async () => {
+    const existing = { mcpServers: { old: { command: 'node old.js' } } };
+    mockFs.readFile.mockResolvedValue(JSON.stringify(existing));
+    mockFs.writeFile.mockResolvedValue(undefined);
+
+    const exporter = createCursorExporter();
+    const result = await exporter.write(registry);
+
+    expect(result.success).toBe(true);
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      '/home/test/.cursor/mcp.json',
+      expect.stringContaining('"global"'),
+      'utf8'
+    );
+
+    const written = JSON.parse(mockFs.writeFile.mock.calls[0][1]);
+    expect(written.mcpServers).toEqual({
+      global: { command: 'npx', args: ['tool'] }
+    });
+  });
+});

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { validateEntry, validateMcpRegistry } from '../src/services/validation.js';
-import type { McpEntry, ValidationError } from '../src/types/index.js';
+import type { McpEntry } from '../src/types/index.js';
 
 describe('validateEntry', () => {
   it('should return empty array for valid entry with command only', () => {

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { validateEntry, validateMcpRegistry } from '../src/services/validation.js';
+import type { McpEntry, ValidationError } from '../src/types/index.js';
+
+describe('validateEntry', () => {
+  it('should return empty array for valid entry with command only', () => {
+    const entry: McpEntry = {
+      command: 'docker'
+    };
+    const result = validateEntry('test', entry);
+    expect(result).toEqual([]);
+  });
+
+  it('should return error for missing command', () => {
+    const entry = {} as McpEntry;
+    const result = validateEntry('test', entry);
+    expect(result).toEqual([
+      { path: 'test.command', reason: 'command is required' }
+    ]);
+  });
+
+  it('should return error for empty command', () => {
+    const entry: McpEntry = {
+      command: ''
+    };
+    const result = validateEntry('test', entry);
+    expect(result).toEqual([
+      { path: 'test.command', reason: 'command cannot be empty' }
+    ]);
+  });
+
+  it('should return error for non-string command', () => {
+    const entry = {
+      command: 123
+    } as unknown as McpEntry;
+    const result = validateEntry('test', entry);
+    expect(result).toEqual([
+      { path: 'test.command', reason: 'command must be a string' }
+    ]);
+  });
+
+  it('should return empty array for valid entry with args', () => {
+    const entry: McpEntry = {
+      command: 'docker',
+      args: ['run', '-i', '--rm']
+    };
+    const result = validateEntry('test', entry);
+    expect(result).toEqual([]);
+  });
+
+  it('should return error for non-array args', () => {
+    const entry = {
+      command: 'docker',
+      args: 'invalid'
+    } as unknown as McpEntry;
+    const result = validateEntry('test', entry);
+    expect(result).toEqual([
+      { path: 'test.args', reason: 'args must be an array' }
+    ]);
+  });
+
+  it('should return error for args with non-string elements', () => {
+    const entry = {
+      command: 'docker',
+      args: ['run', 123, '--rm']
+    } as unknown as McpEntry;
+    const result = validateEntry('test', entry);
+    expect(result).toEqual([
+      { path: 'test.args[1]', reason: 'args elements must be strings' }
+    ]);
+  });
+
+  it('should return empty array for valid entry with env', () => {
+    const entry: McpEntry = {
+      command: 'docker',
+      env: { 'API_KEY': 'test123' }
+    };
+    const result = validateEntry('test', entry);
+    expect(result).toEqual([]);
+  });
+
+  it('should return error for non-object env', () => {
+    const entry = {
+      command: 'docker',
+      env: 'invalid'
+    } as unknown as McpEntry;
+    const result = validateEntry('test', entry);
+    expect(result).toEqual([
+      { path: 'test.env', reason: 'env must be an object' }
+    ]);
+  });
+
+  it('should return error for env with non-string values', () => {
+    const entry = {
+      command: 'docker',
+      env: { 'API_KEY': 123 }
+    } as unknown as McpEntry;
+    const result = validateEntry('test', entry);
+    expect(result).toEqual([
+      { path: 'test.env.API_KEY', reason: 'env values must be strings' }
+    ]);
+  });
+
+  it('should return multiple errors for multiple validation failures', () => {
+    const entry = {
+      command: '',
+      args: 'invalid',
+      env: { 'KEY': 123 }
+    } as unknown as McpEntry;
+    const result = validateEntry('test', entry);
+    expect(result).toHaveLength(3);
+    expect(result).toContainEqual({ path: 'test.command', reason: 'command cannot be empty' });
+    expect(result).toContainEqual({ path: 'test.args', reason: 'args must be an array' });
+    expect(result).toContainEqual({ path: 'test.env.KEY', reason: 'env values must be strings' });
+  });
+});
+
+describe('validateMcpRegistry', () => {
+  it('should return empty array for valid registry', () => {
+    const registry = {
+      'test1': { command: 'docker' },
+      'test2': { command: 'npx', args: ['test'] }
+    };
+    const result = validateMcpRegistry(registry);
+    expect(result).toEqual([]);
+  });
+
+  it('should return errors for invalid entries in registry', () => {
+    const registry = {
+      'valid': { command: 'docker' },
+      'invalid': { command: '' }
+    } as unknown as Record<string, McpEntry>;
+    const result = validateMcpRegistry(registry);
+    expect(result).toEqual([
+      { path: 'invalid.command', reason: 'command cannot be empty' }
+    ]);
+  });
+
+  it('should collect all validation errors from multiple entries', () => {
+    const registry = {
+      'entry1': { command: '' },
+      'entry2': { command: 'valid' },
+      'entry3': { args: 'invalid' }
+    } as unknown as Record<string, McpEntry>;
+    const result = validateMcpRegistry(registry);
+    expect(result).toHaveLength(3);
+    expect(result).toContainEqual({ path: 'entry1.command', reason: 'command cannot be empty' });
+    expect(result).toContainEqual({ path: 'entry3.command', reason: 'command is required' });
+    expect(result).toContainEqual({ path: 'entry3.args', reason: 'args must be an array' });
+  });
+});

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -101,6 +101,46 @@ describe('validateEntry', () => {
     ]);
   });
 
+  it('should return empty array for valid sse entry with headers', () => {
+    const entry = {
+      type: 'sse',
+      url: 'https://example.com/sse',
+      headers: {
+        Authorization: 'Bearer token'
+      }
+    } as unknown as McpEntry;
+
+    const result = validateEntry('remote', entry);
+    expect(result).toEqual([]);
+  });
+
+  it('should return error when sse entry is missing url', () => {
+    const entry = {
+      type: 'sse',
+      headers: {}
+    } as unknown as McpEntry;
+
+    const result = validateEntry('remote', entry);
+    expect(result).toEqual([
+      { path: 'remote.url', reason: 'url is required for transport "sse"' }
+    ]);
+  });
+
+  it('should return error when headers contain non-string values', () => {
+    const entry = {
+      type: 'sse',
+      url: 'https://example.com/sse',
+      headers: {
+        Authorization: 123
+      }
+    } as unknown as McpEntry;
+
+    const result = validateEntry('remote', entry);
+    expect(result).toEqual([
+      { path: 'remote.headers.Authorization', reason: 'header values must be strings' }
+    ]);
+  });
+
   it('should return multiple errors for multiple validation failures', () => {
     const entry = {
       command: '',

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,44 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "removeComments": false,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ],
+  "ts-node": {
+    "esm": true
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,28 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        'src/cli.ts',
+        '.eslintrc.js'
+      ],
+      thresholds: {
+        statements: 90,
+        branches: 90,
+        functions: 90,
+        lines: 90
+      }
+    }
+  }
+});


### PR DESCRIPTION
## 概要
- Commander ベースの manage-mcp CLI を整備し、list/add/remove/import/export を実装
- MCP レジストリ入出力・検証・外部ツール連携サービスと add 記法対応ロジックを追加
- Claude/Cursor/Codex へのインポート・エクスポート、ログ基盤、README/ライセンス/テスト群を整備

## テスト
- npm test -- --run tests/add-command.test.ts
- npm test -- --run tests/validation.test.ts
- npm run lint
- npm run build
